### PR TITLE
Fix x11 window property getter

### DIFF
--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -109,7 +109,7 @@ proc property(
     lenght: culong
     bytesAfter: culong
     data: cstring
-  display.XGetWindowProperty(window, property, 0, 0, false, 0, kind.addr,
+  display.XGetWindowProperty(window, property, 0, -1, false, 0, kind.addr,
       format.addr, lenght.addr, bytesAfter.addr, data.addr)
 
   result.kind = kind

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,1 +1,80 @@
-import windy
+import unittest
+import windy, opengl
+
+import std/monotimes
+
+
+proc nowMs(): float64 =
+  ## Gets current milliseconds.
+  getMonoTime().ticks.float64 / 1000000.0
+
+
+template displayLoop(window: Window, duration: int, body: untyped) =
+  block:
+    proc loopBody() =
+      body
+
+    let start = nowMs()
+
+    while not window.closeRequested:
+      loopBody()
+      pollEvents()
+
+      let delta = nowMs() - start
+      if delta > duration:
+        break
+
+
+test "set and get fullscreen property":
+
+  let window = newWindow("Windy Example", ivec2(1280, 800))
+
+  window.makeContextCurrent()
+  loadExtensions()
+
+  proc display() =
+    glClear(GL_COLOR_BUFFER_BIT)
+    window.swapBuffers()
+
+  window.fullscreen = false
+  displayLoop(window, 1000):
+     display()
+  doAssert not window.fullscreen
+
+  window.fullscreen = true
+  displayLoop(window, 1000):
+     display()
+  doAssert window.fullscreen
+
+  window.fullscreen = false
+  displayLoop(window, 1000):
+     display()
+  doAssert not window.fullscreen
+
+
+test "set and get maximized property":
+
+  let window = newWindow("Windy Example", ivec2(1280, 800))
+
+  window.makeContextCurrent()
+  loadExtensions()
+
+  proc display() =
+    glClear(GL_COLOR_BUFFER_BIT)
+    window.swapBuffers()
+
+  window.maximized = false
+  displayLoop(window, 1000):
+     display()
+  doAssert not window.maximized
+
+  window.maximized = true
+  displayLoop(window, 1000):
+     display()
+  doAssert window.maximized
+
+  window.maximized = false
+  displayLoop(window, 1000):
+     display()
+  doAssert not window.maximized
+


### PR DESCRIPTION
Dear treeform,

I added a few tests to illustrate what I am trying to fix. I am not sure about the design of those tests (and I am not a hardened Nim developer).

Those tests fail before the fix (the fix is in the second commit of this PR) and are green after.

I found how to fix from here: https://chromium.googlesource.com/chromium/chromium/+/3c63f9de10d3b4abd9767cd1f4b85323f1064527/ui/base/x/x11_util.cc line 815.

Feel free to modify or close this PR and to apply the fix differently if you prefer.

Best,
