### PR TITLE
win32, macos transparent windows

### DIFF
--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -93,6 +93,7 @@ const
   NSOpenGLProfileVersion3_2Core* = 0x3200
   NSOpenGLProfileVersion4_1Core* = 0x4100
   NSOpenGLContextParameterSwapInterval* = 222
+  NSOpenGLContextParameterSurfaceOpacity* = 236
   NSTrackingMouseEnteredAndExited* = 0x01.NSTrackingAreaOptions
   NSTrackingMouseMoved* = 0x02.NSTrackingAreaOptions
   NSTrackingCursorUpdate* = 0x04.NSTrackingAreaOptions
@@ -246,6 +247,11 @@ objc:
   proc openGLContext*(self: NSOpenGLView): NSOpenGLContext
   proc makeCurrentContext*(self: NSOpenGLContext)
   proc setValues*(
+    self: NSOpenGLContext,
+    _: ptr GLint,
+    forParameter: NSOpenGLContextParameter
+  )
+  proc getValues*(
     self: NSOpenGLContext,
     _: ptr GLint,
     forParameter: NSOpenGLContextParameter

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -70,6 +70,14 @@ proc fullscreen*(window: Window): bool =
 proc floating*(window: Window): bool =
   window.inner.level == NSFloatingWindowLevel
 
+proc transparent*(window: Window): bool =
+  var opaque: GLint
+  window.inner.contentView.NSOpenGLView.openGLContext.getValues(
+    opaque.addr,
+    NSOpenGLContextParameterSurfaceOpacity
+  )
+  opaque == 0
+
 proc contentScale*(window: Window): float32 =
   autoreleasepool:
     let
@@ -164,6 +172,18 @@ proc `floating=`*(window: Window, floating: bool) =
       else:
         NSNormalWindowLevel
     window.inner.setLevel(level)
+
+proc `transparent=`*(window: Window, transparent: bool) =
+  var opaque: GLint =
+    if transparent:
+      0
+    else:
+      1
+  autoreleasepool:
+    window.inner.contentView.NSOpenGLView.openGLContext.setValues(
+      opaque.addr,
+      NSOpenGLContextParameterSurfaceOpacity
+    )
 
 proc `size=`*(window: Window, size: IVec2) =
   autoreleasepool:

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -278,6 +278,9 @@ proc getDC(hWnd: HWND): HDC =
 proc getWindowStyle(hWnd: HWND): LONG =
   GetWindowLongW(hWnd, GWL_STYLE)
 
+proc getWindowExStyle(hWnd: HWND): LONG =
+  GetWindowLongW(hWnd, GWL_EXSTYLE)
+
 proc updateWindowStyle(hWnd: HWND, style: LONG) =
   var rect: RECT
   discard GetClientRect(hWnd, rect.addr)

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -1290,6 +1290,8 @@ proc getScreens*(): seq[Screen] =
 
   var h = Holder()
 
+  {.push stackTrace: off.}
+
   proc callback(
     hMonitor: HMONITOR,
     hdc: HDC,
@@ -1310,6 +1312,8 @@ proc getScreens*(): seq[Screen] =
     ))
 
     return TRUE
+
+  {.pop.}
 
   discard EnumDisplayMonitors(0, nil, callback, cast[LPARAM](h.addr))
 

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -9,6 +9,7 @@ const
   wheelDelta = 120
   decoratedWindowStyle = WS_OVERLAPPEDWINDOW
   undecoratedWindowStyle = WS_POPUP
+  windowExStyle = WS_EX_APPWINDOW
 
   WGL_DRAW_TO_WINDOW_ARB = 0x2001
   WGL_ACCELERATION_ARB = 0x2003
@@ -63,7 +64,7 @@ type
     state: WindowState
     trackMouseEventRegistered: bool
     exitFullscreenInfo: ExitFullscreenInfo
-    isFloating: bool
+    isFloating, isTransparent: bool
 
     hWnd: HWND
     hdc: HDC
@@ -193,7 +194,7 @@ proc createWindow(windowClassName, title: string): HWND =
     wideTitle = title.wstr()
 
   result = CreateWindowExW(
-    WS_EX_APPWINDOW,
+    windowExStyle,
     cast[ptr WCHAR](wideWindowClassName[0].unsafeAddr),
     cast[ptr WCHAR](wideTitle[0].unsafeAddr),
     decoratedWindowStyle,
@@ -288,7 +289,7 @@ proc updateWindowStyle(hWnd: HWND, style: LONG) =
     rect.addr,
     style,
     0,
-    WS_EX_APPWINDOW,
+    windowExStyle,
     GetDpiForWindow(hWnd)
   )
 
@@ -334,6 +335,9 @@ proc fullscreen*(window: Window): bool =
 
 proc floating*(window: Window): bool =
   window.isFloating
+
+proc transparent*(window: Window): bool =
+  window.isTransparent
 
 proc contentScale*(window: Window): float32 =
   let dpi = GetDpiForWindow(window.hWnd)
@@ -493,6 +497,33 @@ proc `floating=`*(window: Window, floating: bool) =
     SWP_NOMOVE or SWP_NOSIZE or SWP_NOACTIVATE
   )
 
+proc `transparent=`*(window: Window, transparent: bool) =
+  if window.transparent == transparent:
+    return
+
+  window.isTransparent = transparent
+
+  if transparent:
+    let region = CreateRectRgn(0, 0, -1, -1)
+
+    var bb = DWM_BLURBEHIND()
+    bb.dwFlags = DWM_BB_ENABLE or DWM_BB_BLURREGION
+    bb.hRgnBlur = region
+    bb.fEnable = TRUE
+
+    try:
+      if DwmEnableBlurBehindWindow(window.hWnd, bb.addr) != S_OK:
+        raise newException(WindyError, "Error enabling window transparency")
+    finally:
+      discard DeleteObject(region)
+  else:
+    var bb = DWM_BLURBEHIND()
+    bb.dwFlags = DWM_BB_ENABLE or DWM_BB_BLURREGION
+    bb.fEnable = FALSE
+
+    if DwmEnableBlurBehindWindow(window.hWnd, bb.addr) != S_OK:
+      raise newException(WindyError, "Error disabling window transparency")
+
 proc `size=`*(window: Window, size: IVec2) =
   if window.fullscreen:
     return
@@ -502,7 +533,7 @@ proc `size=`*(window: Window, size: IVec2) =
     rect.addr,
     getWindowStyle(window.hWnd),
     0,
-    WS_EX_APPWINDOW,
+    windowExStyle,
     GetDpiForWindow(window.hWnd)
   )
   discard SetWindowPos(
@@ -524,7 +555,7 @@ proc `pos=`*(window: Window, pos: IVec2) =
     rect.addr,
     getWindowStyle(window.hWnd),
     0,
-    WS_EX_APPWINDOW,
+    windowExStyle,
     GetDpiForWindow(window.hWnd)
   )
   discard SetWindowPos(

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -47,6 +47,8 @@ type
   HIMC* = HANDLE
   HBITMAP* = HANDLE
   HINTERNET* = HANDLE
+  HRGN* = HANDLE
+  HGDIOBJ* = HANDLE
   LPVOID* = pointer
   LPCVOID* = pointer
   UINT* = uint32
@@ -192,6 +194,11 @@ type
   WINHTTP_WEB_SOCKET_STATUS* {.pure.} = object
     dwBytesTransferred*: DWORD
     eBufferType*: WINHTTP_WEB_SOCKET_BUFFER_TYPE
+  DWM_BLURBEHIND* {.pure.} = object
+    dwFlags*: DWORD
+    fEnable*: BOOL
+    hRgnBlur*: HRGN
+    fTransitionOnMaximized*: BOOL
 
 type
   wglCreateContext* = proc(hdc: HDC): HGLRC {.stdcall, raises: [].}
@@ -280,6 +287,8 @@ const
   WS_CHILDWINDOW* = WS_CHILD
   WS_EX_APPWINDOW* = 0x00040000
   WS_EX_TOPMOST* = 0x00000008
+  WS_EX_LAYERED* = 0x00080000
+  WS_EX_TRANSPARENT* = 0x00000020
   WM_NULL* = 0x0000
   WM_CREATE* = 0x0001
   WM_DESTROY* = 0x0002
@@ -511,6 +520,8 @@ const
   WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET* = 114
   WINHTTP_ERROR_BASE* = 12000
   ERROR_WINHTTP_HEADER_NOT_FOUND* = WINHTTP_ERROR_BASE + 150
+  DWM_BB_ENABLE* = 0x00000001
+  DWM_BB_BLURREGION* = 0x00000002
 
 {.push importc, stdcall.}
 
@@ -882,6 +893,20 @@ proc DescribePixelFormat*(
 ): int32 {.dynlib: "Gdi32".}
 
 proc SwapBuffers*(hdc: HDC): BOOL {.dynlib: "Gdi32".}
+
+proc CreateRectRgn*(
+  x1: int32,
+  y1: int32,
+  x2: int32,
+  y2: int32
+): HRGN {.dynlib: "Gdi32".}
+
+proc DeleteObject*(ho: HGDIOBJ): BOOL {.dynlib: "Gdi32".}
+
+proc DwmEnableBlurBehindWindow*(
+  hWnd: HWND,
+  pBlurBehind: ptr DWM_BLURBEHIND
+): HRESULT {.dynlib: "Dwmapi"}
 
 proc ImmGetContext*(
   hWnd: HWND


### PR DESCRIPTION
* Undecorated windows work best for transparent windows. On Win32 the decorations (top bar + shadow) remain opaque but OpenGL area is transparent. On macOS, entire window remains opaque if decorated.

* Transparent windows still block the mouse (clicks, drags etc do not go through transparency).