### PR TITLE
fix: x11 xk_e key is now bound to KeyE instead of KeyR

### DIFF
--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -287,7 +287,7 @@ proc keysymToButton(sym: KeySym): Button =
   of xk_b: KeyB
   of xk_c: KeyC
   of xk_d: KeyD
-  of xk_e: KeyR
+  of xk_e: KeyE
   of xk_f: KeyF
   of xk_g: KeyG
   of xk_h: KeyH


### PR DESCRIPTION
E key in X11 was bound to the incorrect key button