### PR TITLE
Fix keyboard input on macos

### DIFF
--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -109,6 +109,44 @@ const
   NSNormalWindowLevel* = 0.NSWindowLevel
   NSFloatingWindowLevel* = 3.NSWindowLevel
 
+type
+
+  NSEventType* = enum
+    NSEventTypeLeftMouseDown      = 1,
+    NSEventTypeLeftMouseUp        = 2,
+    NSEventTypeRightMouseDown     = 3,
+    NSEventTypeRightMouseUp       = 4,
+    NSEventTypeMouseMoved         = 5,
+    NSEventTypeLeftMouseDragged   = 6,
+    NSEventTypeRightMouseDragged  = 7,
+    NSEventTypeMouseEntered       = 8,
+    NSEventTypeMouseExited        = 9,
+    NSEventTypeKeyDown            = 10,
+    NSEventTypeKeyUp              = 11,
+    NSEventTypeFlagsChanged       = 12,
+    NSEventTypeAppKitDefined      = 13,
+    NSEventTypeSystemDefined      = 14,
+    NSEventTypeApplicationDefined = 15,
+    NSEventTypePeriodic           = 16,
+    NSEventTypeCursorUpdate       = 17,
+    NSEventTypeRotate             = 18,
+    NSEventTypeBeginGesture       = 19,
+    NSEventTypeEndGesture         = 20,
+    NSEventTypeScrollWheel        = 22,
+    NSEventTypeTabletPoint        = 23,
+    NSEventTypeTabletProximity    = 24,
+    NSEventTypeOtherMouseDown     = 25,
+    NSEventTypeOtherMouseUp       = 26,
+    NSEventTypeOtherMouseDragged  = 27,
+    NSEventTypeGesture            = 29,
+    NSEventTypeMagnify            = 30,
+    NSEventTypeSwipe              = 31,
+    NSEventTypeSmartMagnify       = 32,
+    NSEventTypeQuickLook          = 33,
+    NSEventTypePressure           = 34,
+    NSEventTypeDirectTouch        = 37
+
+
 var
   NSApp* {.importc.}: NSApplication
   NSPasteboardTypeString* {.importc.}: NSPasteboardType
@@ -139,6 +177,8 @@ objc:
   proc locationInWindow*(self: NSEvent): NSPoint
   proc buttonNumber*(self: NSEvent): int
   proc keyCode*(self: NSEvent): uint16
+  proc type*(self: NSEvent): NSEventType
+  proc window*(self: NSEvent): NSWindow
   proc dataWithBytes*(class: typedesc[NSData], x: pointer, length: int): NSData
   proc length*(self: NSData): uint
   proc bytes*(self: NSData): pointer


### PR DESCRIPTION
Turns out that NSApplication doesn't send `keyUp` events when `command` or other modifiers are being held down. Seems really weird, but it's an old issue.

This means Windy can't remove the non-modifier keys released before modifiers are released.

Here's some background info: 

- https://stackoverflow.com/questions/24099063/how-do-i-detect-keyup-in-my-nsview-with-the-command-key-held
- https://lists.apple.com/archives/cocoa-dev/2003/Oct/msg00442.html
- https://github.com/andlabs/ui/blob/bc848f5c4078b999dbe6ef1cd90e16290a0d1c3a/delegateuitask_darwin.m#L46

Initially I tried to follow their approaches of sub-classing NSApplication. However, it seems Window uses a global `NSApp`. Instead, since Windy already handles all events in `pollEvents` that was much simpler to implement. 



