### PR TITLE
Update x11.nim, handle x11 opengl version better too

### DIFF
--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -579,13 +579,10 @@ proc newWindow*(
   size: IVec2,
   visible = true,
   vsync = true,
-
-  openglMajorVersion = 4,
-  openglMinorVersion = 1,
+  openglVersion = OpenGL4Dot1,
   msaa = msaaDisabled,
   depthBits = 24,
   stencilBits = 8,
-
   transparent = false,
 ): Window =
   ## Creates a new window. Intitializes Windy if needed.


### PR DESCRIPTION
Follow #87, #87 missed the X11 implementation.

I haven't tested this PR because I don't have a suitable Linux environment.
The variables `openglMajorVersion` and `openglMinorVersion` appear to be unused.

close #120.