### PR TITLE
normalize scrolling better

### DIFF
--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -446,7 +446,10 @@ proc onMouseMove(eventType: cint, mouseEvent: ptr EmscriptenMouseEvent, userData
 
 proc onWheel(eventType: cint, wheelEvent: ptr EmscriptenWheelEvent, userData: pointer): EM_BOOL {.cdecl.} =
   let window = cast[Window](userData)
-  window.state.perFrame.scrollDelta += vec2(wheelEvent.deltaX.float32, wheelEvent.deltaY.float32)
+  # Normalize web wheel events to match other platforms.
+  let normalizedDeltaX = wheelEvent.deltaX.float32 * 0.01
+  let normalizedDeltaY = wheelEvent.deltaY.float32 * 0.01
+  window.state.perFrame.scrollDelta += vec2(normalizedDeltaX, normalizedDeltaY)
   if window.onScroll != nil:
     window.onScroll()
   return 1

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -832,10 +832,10 @@ proc pollEvents(window: Window) =
       of 8: pushButtonEvent(MouseButton4)
       of 9: pushButtonEvent(MouseButton5)
 
-      of 4: pushScrollEvent(vec2(0, 1)) # scroll up
-      of 5: pushScrollEvent(vec2(0, -1)) # scroll down
-      of 6: pushScrollEvent(vec2(-1, 0)) # scroll left?
-      of 7: pushScrollEvent(vec2(1, 0)) # scroll right?
+      of 4: pushScrollEvent(vec2(0, 10.0)) # scroll up
+      of 5: pushScrollEvent(vec2(0, -10.0)) # scroll down
+      of 6: pushScrollEvent(vec2(-10.0, 0)) # scroll left
+      of 7: pushScrollEvent(vec2(10.0, 0)) # scroll right
       else: discard
 
       if not isDblclk:


### PR DESCRIPTION
mettascope2 had:
```
when defined(emscripten):
        let scrollK = 0.0003
 ```
but it would be better to just have more consistent scrolling.
        
tested these values on my linux system both on desktop and emscripten.