### PR TITLE
bump setup-nim-action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: jiro4989/setup-nim-action@v1
+    - uses: jiro4989/setup-nim-action@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - run: nimble test -y


### PR DESCRIPTION
possible fix for the windows setup issue?

 Error: Command failed: bash init.sh -y
dynlib.nim(64)           raiseInvalidLibrary
Error: unhandled exception: could not find symbol: SSL_library_init [LibraryError]