### PR TITLE
fix scaling on linux x11

### DIFF
--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -1,8 +1,8 @@
 import
   std/[os, sequtils, sets, strformat, strutils, times, unicode],
-  ../../common, ../../internal,
+  ../../[common, internal],
   vmath, pixie,
-  x11/glx, x11/keysym, x11/x, x11/xevent, x11/xlib, x11/xcursor
+  x11/[glx, keysym, x, xevent, xlib, xcursor]
 
 import ../../http
 export http
@@ -569,26 +569,18 @@ proc `title=`*(window: Window, v: string) =
 proc contentScale*(window: Window): float32 =
   const defaultScreenDpi = 96.0
   
-  # Try to get DPI from Xft.dpi resource (most reliable for user scaling).
+  # Prefer using DPI from Xft.dpi resource for user scaling.
   let xftDpi = display.XGetDefault("Xft", "dpi")
   if xftDpi != nil:
     try:
       let dpi = parseFloat($xftDpi)
       if dpi > 0:
-        echo &"Using Xft.dpi: {dpi} (scale: {dpi / defaultScreenDpi})"
         return dpi / defaultScreenDpi
     except ValueError:
       discard
   
-  
-  # Fall back to physical screen dimensions.
-  const pixelsPerMillimeter = 25.4
-  let s = display.screen(display.defaultScreen)
-  echo &"Screen size: {s.size}, Physical: {s.msize} mm"
-  let dpiX = s.size.x.float * pixelsPerMillimeter / s.msize.x.float
-  let dpiY = s.size.y.float * pixelsPerMillimeter / s.msize.y.float
-  echo &"Calculated DPI: {dpiX} x {dpiY}"
-  return (s.size.vec2 * pixelsPerMillimeter / s.msize.vec2 / defaultScreenDpi).x
+  # otherwise assume no scaling.
+  return 1.0
 
 proc runeInputEnabled*(window: Window): bool =
   window.runeInputEnabled

--- a/src/windy/platforms/linux/x11/xlib.nim
+++ b/src/windy/platforms/linux/x11/xlib.nim
@@ -309,6 +309,9 @@ proc XSetTransientForHint*(d: Display, window: Window; root: Window)
 proc XSetNormalHints*(d: Display, window: Window; hints: ptr XSizeHints)
 proc XGetNormalHints*(d: Display, window: Window; res: ptr XSizeHints)
 
+proc XResourceManagerString*(d: Display): cstring {.importc, dynlib: libX11.}
+proc XGetDefault*(d: Display; program: cstring; option: cstring): cstring {.importc, dynlib: libX11.}
+
 proc XGetGeometry*(
   d: Display, window: Drawable;
   root: ptr Window;


### PR DESCRIPTION
- check for the dpi property and set scaling appropriately. tested working on wayland + gnome for 100% and 200%, works fine.
- otherwise default to 1.

- The previous logic was giving 1.004923, on my machine, which seems not great. a default of 1 should be great, and if we do need to fix more cases of scaling in other desktop environments, we should fix those cases specifically.