### PR TITLE
List individual Linux monitors so games can choose a display

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
     - name: Check two X11 monitors
       if: matrix.os == 'ubuntu-latest'
       run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y x11-xserver-utils
         xvfb-run -a -s "-noreset -screen 0 1600x600x24" sh -ec '
           xrandr --setmonitor LEFT 800/200x600/150+0+0 screen
           xrandr --setmonitor RIGHT 800/200x600/150+800+0 none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,15 @@ jobs:
     - run: nim r -d:useCpu tests/test_cpu_pixels.nim
       if: matrix.os == 'windows-latest'
 
+    - name: Check two X11 monitors
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        xvfb-run -a -s "-noreset -screen 0 1600x600x24" sh -ec '
+          xrandr --setmonitor LEFT 800/200x600/150+0+0 screen
+          xrandr --setmonitor RIGHT 800/200x600/150+800+0 none
+          nim r --parallelBuild:1 tests/test_screens.nim
+        '
+
     # Build native examples.
     - run: nim c examples/basic.nim
     - run: nim c examples/basic_boxy.nim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,6 @@ jobs:
     - run: nim r -d:useCpu tests/test_cpu_pixels.nim
       if: matrix.os == 'windows-latest'
 
-    - name: Check two X11 monitors
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y x11-xserver-utils
-        xvfb-run -a -s "-noreset -screen 0 1600x600x24" sh -ec '
-          xrandr --setmonitor LEFT 800/200x600/150+0+0 screen
-          xrandr --setmonitor RIGHT 800/200x600/150+800+0 none
-          nim r --parallelBuild:1 tests/test_screens.nim
-        '
-
     # Build native examples.
     - run: nim c examples/basic.nim
     - run: nim c examples/basic_boxy.nim
@@ -65,6 +54,17 @@ jobs:
     - run: nim c examples/openurl.nim
     - run: nim c examples/property_changes.nim
     - run: nim c examples/screens.nim
+    - name: Check two X11 monitors
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y x11-xserver-utils
+        xvfb-run -a -s "-noreset -screen 0 1600x600x24" sh -ec '
+          xrandr --setmonitor LEFT 800/200x600/150+0+0 screen
+          xrandr --setmonitor RIGHT 800/200x600/150+800+0 none
+          nim r --parallelBuild:1 tests/test_screens.nim
+        '
+
     - run: nim c examples/scrollwheel.nim
     - run: nim c examples/system_cursors.nim
     - run: nim c examples/tray.nim

--- a/examples/screens.nim
+++ b/examples/screens.nim
@@ -1,8 +1,4 @@
 import windy
 
-when defined(windows) or defined(macosx):
-  # Screens API only currently supported on Windows and macOS
-
-  let screens = getScreens()
-  for screen in screens:
-    echo screen
+for screen in getScreens():
+  echo screen

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -625,6 +625,23 @@ proc `title=`*(window: Window, v: string) =
   window.handle.setProperty(xaNetWMIconName, xaUTF8String, 8, v)
   display.Xutf8SetWMProperties(window.handle, v, v, nil, 0, nil, nil, nil)
 
+proc getScreens*(): seq[common.Screen] =
+  ## Returns the default X11 screen as primary.
+  init()
+
+  let screen = display.screen(display.defaultScreen)
+  if screen == nil:
+    return
+
+  let size = screen.size
+  result.add common.Screen(
+    left: 0,
+    top: 0,
+    right: size.x,
+    bottom: size.y,
+    primary: true
+  )
+
 proc contentScale*(window: Window): float32 =
   const defaultScreenDpi = 96.0
 

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -2,7 +2,7 @@ import
   std/[os, osproc, sequtils, sets, strformat, strutils, times, unicode, uri, pathnorm],
   ../../[common, internal],
   vmath, pixie,
-  x11/[glx, keysym, x, xevent, xlib, xcursor]
+  x11/[glx, keysym, x, xevent, xlib, xcursor, xrandr]
 
 import ../../http
 export http
@@ -626,21 +626,25 @@ proc `title=`*(window: Window, v: string) =
   display.Xutf8SetWMProperties(window.handle, v, v, nil, 0, nil, nil, nil)
 
 proc getScreens*(): seq[common.Screen] =
-  ## Returns the default X11 screen as primary.
+  ## Returns active X11 monitors and their desktop positions (RandR 1.5).
   init()
-
-  let screen = display.screen(display.defaultScreen)
-  if screen == nil:
+  var major, minor, count: cint
+  if display.XRRQueryVersion(major.addr, minor.addr) == 0 or
+      (major == 1 and minor < 5) or major < 1:
+    raise WindyError.newException("Screen enumeration requires RandR 1.5")
+  let monitors = display.XRRGetMonitors(display.defaultRootWindow, 1, count.addr)
+  if monitors == nil:
     return
-
-  let size = screen.size
-  result.add common.Screen(
-    left: 0,
-    top: 0,
-    right: size.x,
-    bottom: size.y,
-    primary: true
-  )
+  defer: XRRFreeMonitors(monitors)
+  for i in 0 ..< count:
+    let monitor = monitors[i]
+    result.add common.Screen(
+      left: monitor.x,
+      top: monitor.y,
+      right: monitor.x + monitor.width,
+      bottom: monitor.y + monitor.height,
+      primary: monitor.primary != 0
+    )
 
 proc contentScale*(window: Window): float32 =
   const defaultScreenDpi = 96.0

--- a/src/windy/platforms/linux/x11/xrandr.nim
+++ b/src/windy/platforms/linux/x11/xrandr.nim
@@ -1,0 +1,15 @@
+import x, xlib
+
+type
+  XRRMonitorInfo* {.bycopy.} = object
+    name*: Atom
+    primary*, automatic*, noutput*: cint
+    x*, y*, width*, height*, mwidth*, mheight*: cint
+    outputs*: ptr culong
+
+{.push cdecl, dynlib: "libXrandr.so.2", importc.}
+proc XRRQueryVersion*(display: Display, major, minor: ptr cint): cint
+proc XRRGetMonitors*(display: Display, window: Window, active: cint,
+    count: ptr cint): ptr UncheckedArray[XRRMonitorInfo]
+proc XRRFreeMonitors*(monitors: ptr UncheckedArray[XRRMonitorInfo])
+{.pop.}

--- a/tests/test_screens.nim
+++ b/tests/test_screens.nim
@@ -1,0 +1,10 @@
+## Run on the two-monitor Xvfb layout configured by the build workflow.
+import windy, std/algorithm
+var screens = getScreens()
+screens.sort(proc(a, b: Screen): int = cmp(a.left, b.left))
+doAssert screens.len == 2, "each monitor must be returned separately"
+doAssert screens[0].left == 0 and screens[0].right == 800
+doAssert screens[1].left == 800 and screens[1].right == 1600
+for screen in screens:
+  doAssert screen.top == 0 and screen.bottom == 600
+echo "Two distinct X11 monitor bounds passed"


### PR DESCRIPTION
## Summary

Return each active X11 monitor’s position, size, and primary status instead of one rectangle for the whole desktop. Games can use that information to open a window on a chosen display. This requires RandR 1.5 support.

## Details

Games need each monitor’s position and size to place a window on the chosen display. The old change returned one rectangle covering the desktop, so it could not distinguish two monitors.

Use RandR 1.5 to return active monitor rectangles and their primary flags. This requires libXrandr and a server supporting RandR 1.5. The example prints the result on every supported platform, including the browser.

Validation: on a real Xvfb server configured with two 800 by 600 monitor regions, the old code returned one 1600 by 600 rectangle. The new test returns two distinct rectangles. A rendered check used those bounds to place two colored windows, one inside each region. This is virtual-monitor runtime evidence, not a physical multi-monitor or hot-plug test. The regression runs in the existing Linux CI job.

Updated to current upstream master. Addresses the existing request to return every screen.

[The implementation checks](https://github.com/treeform/windy/actions/runs/34400466653) passed on Linux, macOS, and Windows. The final change only moves this test step beside the screen example so it combines with the pending VSync PR; its [final run](https://github.com/treeform/windy/actions/runs/34401323664) has also passed on all three platforms. The runtime limits above still apply.

[Codex, acting on behalf of relh]
