### PR TITLE
Add CPU pixel presentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
 
     # Run tests.
     - run: nim c tests/test.nim
+    - run: nim r -d:useCpu tests/test_cpu_pixels.nim
+      if: matrix.os == 'windows-latest'
 
     # Build native examples.
     - run: nim c examples/basic.nim

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **This library is still in development and is not ready to use.**
 
 Windy is a windowing library for Nim that uses native OS APIs to
-manage windows, set up OpenGL, and receive mouse and keyboard input.
+manage windows, set up OpenGL or CPU pixel presentation, and receive mouse and
+keyboard input.
 
 `nimble install windy`
 
@@ -50,6 +51,12 @@ while not window.closeRequested:
 ```
 
 [Check out more examples here.](https://github.com/treeform/windy/tree/master/examples)
+
+## CPU Pixels
+
+On Windows, compile with `-d:useCpu` to create a plain window without an
+OpenGL context. CPU renderers can update the client area by passing a Pixie
+image to `window.presentPixels(image)`.
 
 
 ### Why not just use GLFW or SDL?

--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -1,5 +1,10 @@
-import opengl, objc
+import objc
 export objc
+
+when defined(useCpu):
+  type GLint* = int32
+else:
+  import opengl
 
 {.passL: "-framework Cocoa".}
 
@@ -238,6 +243,7 @@ objc:
   proc bounds*(self: NSView): NSRect
   proc removeTrackingArea*(self: NSView, x: NSTrackingArea)
   proc addTrackingArea*(self: NSView, x: NSTrackingArea)
+  proc setNeedsDisplay*(self: NSView, x: bool)
   proc addCursorRect*(self: NSview, x: NSRect, cursor: NSCursor)
   proc inputContext*(self: NSView): NSTextInputContext
   proc initWithAttributes*(
@@ -274,6 +280,7 @@ objc:
     userInfo: ID
   ): NSTrackingArea
   proc initWithData*(self: NSImage, x: NSData): NSImage
+  proc drawInRect*(self: NSImage, x: NSRect)
   proc initWithImage*(self: NSCursor, x: NSImage, hotSpot: NSPoint): NSCursor
   proc arrowCursor*(class: typedesc[NSCursor]): NSCursor
   proc IBeamCursor*(class: typedesc[NSCursor]): NSCursor

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -5,6 +5,8 @@ import
 
 when defined(useMetal4):
   {.hint: "Using Metal backend".}
+elif defined(useCpu):
+  {.hint: "Using CPU backend".}
 else:
   import opengl
   {.hint: "Using OpenGL backend".}
@@ -37,6 +39,7 @@ type
     # AppKit applies this state asynchronously via delegate callbacks.
     fullscreenState: bool
     minimizedState: bool
+    cpuImage: NSImage
 
 const
   decoratedResizableWindowMask =
@@ -80,7 +83,7 @@ proc style*(window: Window): WindowStyle =
     else:
       Decorated
   else:
-    when defined(useMetal4):
+    when defined(useMetal4) or defined(useCpu):
       Undecorated
     else:
       var opaque: GLint
@@ -178,9 +181,9 @@ proc `style=`*(window: Window, windowStyle: WindowStyle) =
     of Undecorated, Transparent:
       window.inner.setStyleMask(undecoratedWindowMask)
 
-    when defined(useMetal4):
+    when defined(useMetal4) or defined(useCpu):
       if windowStyle == Transparent:
-        warn "Transparent style is not supported by useMetal4 on macOS"
+        warn "Transparent style is not supported by this backend on macOS"
     else:
       var opaque: GLint = if windowStyle == Transparent: 0 else: 1
       autoreleasepool:
@@ -759,6 +762,15 @@ proc resetCursorRects(self: ID, cmd: SEL): ID {.cdecl.} =
 
   self.NSView.addCursorRect(self.NSView.bounds, cursor)
 
+proc drawRect(self: ID, cmd: SEL, dirtyRect: NSRect): ID {.cdecl.} =
+  when defined(useCpu):
+    let window = windows.forNSWindow(self.NSView.window)
+    if window == nil or window.cpuImage.int == 0:
+      return
+    window.cpuImage.drawInRect(self.NSView.bounds)
+  else:
+    discard
+
 proc init() {.raises: [].} =
   if initialized:
     return
@@ -782,7 +794,7 @@ proc init() {.raises: [].} =
       addMethod "windowDidResignKey:", windowDidResignKey
       addMethod "windowShouldClose:", windowShouldClose
 
-    when defined(useMetal4):
+    when defined(useMetal4) or defined(useCpu):
       addClass "WindyView", "NSView", WindyView:
         addProtocol "NSTextInputClient"
         addMethod "acceptsFirstResponder", acceptsFirstResponder
@@ -813,6 +825,8 @@ proc init() {.raises: [].} =
         addMethod "firstRectForCharacterRange:actualRange:", firstRectForCharacterRange
         addMethod "doCommandBySelector:", doCommandBySelector
         addMethod "resetCursorRects", resetCursorRects
+        when defined(useCpu):
+          addMethod "drawRect:", drawRect
     else:
       addClass "WindyView", "NSOpenGLView", WindyView:
         addProtocol "NSTextInputClient"
@@ -941,16 +955,30 @@ proc centerWindow(window: Window) =
   window.pos = ivec2(x.int32, y.int32)
 
 proc makeContextCurrent*(window: Window) =
-  when defined(useMetal4):
+  when defined(useMetal4) or defined(useCpu):
     discard
   else:
     window.inner.contentView.NSOpenGLView.openGLContext.makeCurrentContext()
 
 proc swapBuffers*(window: Window) =
-  when defined(useMetal4):
+  when defined(useMetal4) or defined(useCpu):
     discard
   else:
     window.inner.contentView.NSOpenGLView.openGLContext.flushBuffer()
+
+proc presentPixels*(window: Window, image: Image) =
+  ## Presents a CPU-rendered Pixie image into the macOS window content view.
+  when defined(useCpu):
+    if image == nil or image.width <= 0 or image.height <= 0:
+      return
+    let encodedPng = image.encodePng()
+    window.cpuImage = NSImage.alloc().initWithData(NSData.dataWithBytes(
+      encodedPng[0].unsafeAddr,
+      encodedPng.len
+    ))
+    window.inner.contentView.setNeedsDisplay(true)
+  else:
+    discard
 
 proc close*(window: Window) =
   window.onCloseRequest = nil
@@ -991,7 +1019,7 @@ proc newWindow*(
 
   init()
 
-  when defined(useMetal4):
+  when defined(useMetal4) or defined(useCpu):
     discard
   else:
     let openGlProfile: uint32 = case openglVersion:
@@ -1008,13 +1036,13 @@ proc newWindow*(
       false
     )
 
-    when defined(useMetal4):
-      let metalView = WindyView.alloc().NSView.initWithFrame(
+    when defined(useMetal4) or defined(useCpu):
+      let nativeView = WindyView.alloc().NSView.initWithFrame(
         result.inner.contentView.frame
       )
       result.inner.setDelegate(result.inner.ID)
-      result.inner.setContentView(metalView)
-      discard result.inner.makeFirstResponder(metalView)
+      result.inner.setContentView(nativeView)
+      discard result.inner.makeFirstResponder(nativeView)
     else:
       let
         pixelFormatAttribs = [

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -8,6 +8,8 @@ when defined(useDirectX):
   {.hint: "Using DirectX backend".}
 elif defined(useVulkan):
   {.hint: "Using Vulkan backend".}
+elif defined(useCpu):
+  {.hint: "Using CPU backend".}
 else:
   # OpenGL
   {.hint: "Using OpenGL backend".}
@@ -81,6 +83,7 @@ type
     hWnd: HWND
     hdc: HDC
     hglrc: HGLRC
+    cpuPresentBuffer: seq[uint8]
     vsync*: bool
     iconHandle: HICON
     customCursor: HCURSOR
@@ -223,7 +226,7 @@ proc createWindow(windowClassName, title: string): HWND =
   if result == 0:
     raise newException(WindyError, "Creating native window failed")
 
-when defined(useDirectX) or defined(useVulkan):
+when defined(useDirectX) or defined(useVulkan) or defined(useCpu):
   proc destoryGraphicsContext(window: Window) =
     discard
 else: # OpenGL
@@ -1050,7 +1053,7 @@ proc wndProc(
 
   DefWindowProcW(hWnd, uMsg, wParam, lParam)
 
-when defined(useDirectX) or defined(useVulkan):
+when defined(useDirectX) or defined(useVulkan) or defined(useCpu):
 
   proc loadGraphicsContext() =
     discard
@@ -1174,6 +1177,69 @@ else: # OpenGL
 
     if wglSwapIntervalEXT(if vsync: 1 else: 0) == 0:
       raise newException(WindyError, "Error setting swap interval")
+
+when defined(useCpu):
+  proc straightChannel(channel, alpha: uint8): uint8 {.inline.} =
+    if alpha == 0:
+      return 0
+    if alpha == 255:
+      return channel
+
+    let value =
+      (channel.uint32 * 255'u32 + alpha.uint32 div 2) div alpha.uint32
+    if value > 255'u32:
+      255'u8
+    else:
+      value.uint8
+
+  proc presentPixels*(window: Window, image: Image) =
+    ## Presents a CPU-rendered Pixie image into the Win32 window client area.
+    if image == nil or image.width <= 0 or image.height <= 0:
+      return
+    if window.hdc == 0:
+      raise newException(WindyError, "Window device context is not available")
+
+    let clientSize = window.size
+    if clientSize.x <= 0 or clientSize.y <= 0:
+      return
+
+    let byteLen = image.width * image.height * 4
+    window.cpuPresentBuffer.setLen(byteLen)
+    for i in 0 ..< image.data.len:
+      let
+        color = image.data[i]
+        dst = i * 4
+      window.cpuPresentBuffer[dst + 0] = straightChannel(color.b, color.a)
+      window.cpuPresentBuffer[dst + 1] = straightChannel(color.g, color.a)
+      window.cpuPresentBuffer[dst + 2] = straightChannel(color.r, color.a)
+      window.cpuPresentBuffer[dst + 3] = color.a
+
+    var bmi: BITMAPINFO
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER).DWORD
+    bmi.bmiHeader.biWidth = image.width.LONG
+    bmi.bmiHeader.biHeight = -image.height.LONG
+    bmi.bmiHeader.biPlanes = 1
+    bmi.bmiHeader.biBitCount = 32
+    bmi.bmiHeader.biCompression = BI_RGB
+    bmi.bmiHeader.biSizeImage = byteLen.DWORD
+
+    let scanLines = StretchDIBits(
+      window.hdc,
+      0,
+      0,
+      clientSize.x,
+      clientSize.y,
+      0,
+      0,
+      image.width.int32,
+      image.height.int32,
+      cast[pointer](window.cpuPresentBuffer[0].addr),
+      bmi.addr,
+      DIB_RGB_COLORS.UINT,
+      SRCCOPY.DWORD
+    )
+    if scanLines == GDI_ERROR:
+      raise newException(WindyError, "Error presenting CPU pixels")
 
 
 proc init() {.raises: [].} =

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -199,6 +199,26 @@ type
     fEnable*: BOOL
     hRgnBlur*: HRGN
     fTransitionOnMaximized*: BOOL
+  RGBQUAD* {.pure.} = object
+    rgbBlue*: BYTE
+    rgbGreen*: BYTE
+    rgbRed*: BYTE
+    rgbReserved*: BYTE
+  BITMAPINFOHEADER* {.pure.} = object
+    biSize*: DWORD
+    biWidth*: LONG
+    biHeight*: LONG
+    biPlanes*: WORD
+    biBitCount*: WORD
+    biCompression*: DWORD
+    biSizeImage*: DWORD
+    biXPelsPerMeter*: LONG
+    biYPelsPerMeter*: LONG
+    biClrUsed*: DWORD
+    biClrImportant*: DWORD
+  BITMAPINFO* {.pure.} = object
+    bmiHeader*: BITMAPINFOHEADER
+    bmiColors*: array[1, RGBQUAD]
 
 type
   wglCreateContext* = proc(hdc: HDC): HGLRC {.stdcall, raises: [].}
@@ -541,6 +561,10 @@ const
   ERROR_WINHTTP_HEADER_NOT_FOUND* = WINHTTP_ERROR_BASE + 150
   DWM_BB_ENABLE* = 0x00000001
   DWM_BB_BLURREGION* = 0x00000002
+  BI_RGB* = 0
+  DIB_RGB_COLORS* = 0
+  SRCCOPY* = 0x00CC0020
+  GDI_ERROR* = -1
 
 {.push importc, stdcall.}
 
@@ -914,6 +938,22 @@ proc DescribePixelFormat*(
 ): int32 {.dynlib: "Gdi32".}
 
 proc SwapBuffers*(hdc: HDC): BOOL {.dynlib: "Gdi32".}
+
+proc StretchDIBits*(
+  hdc: HDC,
+  xDest: int32,
+  yDest: int32,
+  DestWidth: int32,
+  DestHeight: int32,
+  xSrc: int32,
+  ySrc: int32,
+  SrcWidth: int32,
+  SrcHeight: int32,
+  lpBits: pointer,
+  lpbmi: ptr BITMAPINFO,
+  iUsage: UINT,
+  rop: DWORD
+): int32 {.dynlib: "Gdi32".}
 
 proc CreateRectRgn*(
   x1: int32,

--- a/tests/test_cpu_pixels.nim
+++ b/tests/test_cpu_pixels.nim
@@ -1,4 +1,4 @@
-when defined(useCpu) and defined(windows):
+when defined(useCpu) and (defined(windows) or defined(macosx)):
   import pixie, windy
 
   let window = newWindow(

--- a/tests/test_cpu_pixels.nim
+++ b/tests/test_cpu_pixels.nim
@@ -1,0 +1,17 @@
+when defined(useCpu) and defined(windows):
+  import pixie, windy
+
+  let window = newWindow(
+    "Windy CPU pixels smoke test",
+    ivec2(32, 32),
+    visible = false,
+    vsync = false
+  )
+  let image = newImage(32, 32)
+  image.fill(color(0.2, 0.4, 0.8, 1.0))
+  window.presentPixels(image)
+  window.close()
+
+  echo "Windy CPU pixels smoke test passed"
+else:
+  echo "Windy CPU pixels smoke test skipped"


### PR DESCRIPTION
## Summary
- Add a `-d:useCpu` Windy backend path that creates windows without an OpenGL context.
- Add `window.presentPixels(image)` for CPU-rendered Pixie images.
- Present CPU pixels through Win32 `StretchDIBits` on Windows.
- Present CPU pixels through a plain AppKit `NSView` on macOS.
- Keep CPU smoke coverage for both Windows and macOS.

## Validation
- `nim r -d:useCpu tests/test_cpu_pixels.nim` on macOS
- `nim check --os:windows -d:useCpu tests/test_cpu_pixels.nim`
- `git diff --check`