### PR TITLE
add mouse capture and release API

### DIFF
--- a/src/windy/internal.nim
+++ b/src/windy/internal.nim
@@ -11,6 +11,7 @@ type
     cursor*: Cursor
     closeRequested*, closed*: bool
     hasPrevMouse*: bool
+    mouseCaptured*: bool
     mousePos*, mousePrevPos*: IVec2
     buttonDown*, buttonToggle*: set[Button]
     perFrame*: PerFrame

--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -287,6 +287,23 @@ proc mousePrevPos*(window: Window): IVec2 =
 proc mouseDelta*(window: Window): IVec2 =
   (window.state.perFrame.mouseDelta.vec2 * window.contentScale).ivec2
 
+proc mouseCaptured*(window: Window): bool =
+  ## Returns true when the mouse is captured for relative look.
+  window.state.mouseCaptured
+
+proc captureMouse*(window: Window) =
+  ## Hide the cursor and report unbounded relative mouse deltas.
+  if window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = true
+  warn "Mouse capture is not implemented on Emscripten yet"
+
+proc releaseMouse*(window: Window) =
+  ## Show the cursor and restore normal absolute mouse tracking.
+  if not window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = false
+
 proc scrollDelta*(window: Window): Vec2 =
   window.state.perFrame.scrollDelta
 

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -46,6 +46,7 @@ type
     closeRequested, closed: bool
     innerDecorated: bool
     innerFocused: bool
+    mouseCaptured: bool
 
     # XDnD state
     xdndSource: XWindow
@@ -1155,6 +1156,23 @@ proc mousePrevPos*(window: Window): IVec2 =
 
 proc mouseDelta*(window: Window): IVec2 =
   window.perFrame.mouseDelta
+
+proc mouseCaptured*(window: Window): bool =
+  ## Returns true when the mouse is captured for relative look.
+  window.mouseCaptured
+
+proc captureMouse*(window: Window) =
+  ## Hide the cursor and report unbounded relative mouse deltas.
+  if window.mouseCaptured:
+    return
+  window.mouseCaptured = true
+  warn "Mouse capture is not implemented on Linux yet"
+
+proc releaseMouse*(window: Window) =
+  ## Show the cursor and restore normal absolute mouse tracking.
+  if not window.mouseCaptured:
+    return
+  window.mouseCaptured = false
 
 proc scrollDelta*(window: Window): Vec2 =
   window.perFrame.scrollDelta

--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -2,6 +2,7 @@ import opengl, objc
 export objc
 
 {.passL: "-framework Cocoa".}
+{.passL: "-framework ApplicationServices".}
 
 type
   CGPoint* {.pure, bycopy.} = object
@@ -143,6 +144,8 @@ objc:
   proc scrollingDeltaX*(self: NSEvent): float64
   proc scrollingDeltaY*(self: NSEvent): float64
   proc hasPreciseScrollingDeltas*(self: NSEvent): bool
+  proc deltaX*(self: NSEvent): float64
+  proc deltaY*(self: NSEvent): float64
   proc locationInWindow*(self: NSEvent): NSPoint
   proc buttonNumber*(self: NSEvent): int
   proc keyCode*(self: NSEvent): uint16
@@ -245,6 +248,8 @@ objc:
   proc level*(self: NSWindow): NSWindowLevel
   proc setLevel*(self: NSWindow, x: NSWindowLevel)
   proc convertRectToBacking*(self: NSView, x: NSRect): NSRect
+  proc convertPoint*(self: NSView, x: NSPoint, toView: NSView): NSPoint
+  proc convertPointToScreen*(self: NSWindow, x: NSPoint): NSPoint
   proc window*(self: NSView): NSWindow
   proc bounds*(self: NSView): NSRect
   proc removeTrackingArea*(self: NSView, x: NSTrackingArea)
@@ -299,6 +304,8 @@ objc:
   proc resizeDownCursor*(class: typedesc[NSCursor]): NSCursor
   proc resizeUpDownCursor*(class: typedesc[NSCursor]): NSCursor
   proc operationNotAllowedCursor*(class: typedesc[NSCursor]): NSCursor
+  proc hide*(class: typedesc[NSCursor])
+  proc unhide*(class: typedesc[NSCursor])
   proc discardMarkedText*(self: NSTextInputContext)
   proc handleEvent*(self: NSTextInputContext, x: NSEvent): bool
   proc deactivate*(self: NSTextInputContext)
@@ -310,6 +317,16 @@ objc:
     x: NSBitmapImageFileType,
     properties: NSDictionary
   ): NSData
+
+proc CGAssociateMouseAndMouseCursorPosition*(
+  connected: bool
+): int32 {.importc, header: "<ApplicationServices/ApplicationServices.h>".}
+
+{.emit: "#include <ApplicationServices/ApplicationServices.h>".}
+
+proc cgWarpMouseCursorPosition*(x, y: float64) =
+  ## Warp the cursor; emit avoids Nim/CGPoint type clash.
+  {.emit: "CGWarpMouseCursorPosition((CGPoint){.x = `x`, .y = `y`});".}
 
 {.push inline.}
 

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -273,6 +273,44 @@ proc `cursor=`*(window: Window, cursor: Cursor) =
   autoreleasepool:
     window.inner.invalidateCursorRectsForView(window.inner.contentView)
 
+proc mouseCaptured*(window: Window): bool =
+  ## Returns true when the mouse is captured for relative look.
+  window.state.mouseCaptured
+
+proc warpCursorToCenter(window: Window) =
+  ## Move the system cursor to the window content center.
+  let
+    view = window.inner.contentView
+    bounds = view.bounds
+    local = NSMakePoint(bounds.size.width / 2, bounds.size.height / 2)
+    inWindow = view.convertPoint(local, 0.NSView)
+    inScreen = window.inner.convertPointToScreen(inWindow)
+    # Cocoa screen space is bottom-left; CG warp is top-left.
+    primary = NSScreen.screens.objectAtIndex(0).NSScreen.frame
+    cgY = primary.origin.y + primary.size.height - inScreen.y
+  cgWarpMouseCursorPosition(inScreen.x, cgY)
+  window.state.mousePos = (vec2(local.x, local.y) * window.contentScale).ivec2
+  window.state.mousePrevPos = window.state.mousePos
+  window.state.hasPrevMouse = false
+
+proc captureMouse*(window: Window) =
+  ## Hide the cursor and report unbounded relative mouse deltas.
+  if window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = true
+  window.warpCursorToCenter()
+  discard CGAssociateMouseAndMouseCursorPosition(false)
+  NSCursor.hide()
+
+proc releaseMouse*(window: Window) =
+  ## Show the cursor and restore normal absolute mouse tracking.
+  if not window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = false
+  discard CGAssociateMouseAndMouseCursorPosition(true)
+  NSCursor.unhide()
+  window.state.hasPrevMouse = false
+
 proc url*(window: Window): string =
   ## Url cannot be gotten on macOS windows.
   warn "Url cannot be gotten on macOS windows"
@@ -292,6 +330,16 @@ proc handleMouseMove(window: Window, location: NSPoint) =
     window.state.perFrame.mouseDelta = ivec2(0, 0)
   window.state.hasPrevMouse = true
 
+  if window.onMouseMove != nil:
+    window.onMouseMove()
+
+proc handleMouseDelta(window: Window, event: NSEvent) =
+  ## Relative deltas while captured. NSEvent deltaY is up-positive.
+  let scale = window.contentScale
+  window.state.perFrame.mouseDelta += ivec2(
+    round(event.deltaX * scale).int32,
+    round(-event.deltaY * scale).int32
+  )
   if window.onMouseMove != nil:
     window.onMouseMove()
 
@@ -417,7 +465,8 @@ proc windowDidBecomeKey(
   clearButtonsTemplate()
   if window.onFocusChange != nil:
     window.onFocusChange()
-  handleMouseMove(window, window.inner.mouseLocationOutsideOfEventStream)
+  if not window.state.mouseCaptured:
+    handleMouseMove(window, window.inner.mouseLocationOutsideOfEventStream)
 
 proc windowDidResignKey(
   self: ID,
@@ -432,6 +481,8 @@ proc windowDidResignKey(
     window.onFocusChange()
   # When loosing focus, prev mouse position is not valid.
   window.state.hasPrevMouse = false
+  # Alt-tab and focus loss always release capture.
+  window.releaseMouse()
 
 proc windowShouldClose(
   self: ID,
@@ -497,7 +548,10 @@ proc mouseMoved(self: ID, cmd: SEL, event: NSEvent): ID {.cdecl.} =
   let window = windows.forNSWindow(self.NSView.window)
   if window == nil:
     return
-  handleMouseMove(window, event.locationInWindow)
+  if window.state.mouseCaptured:
+    handleMouseDelta(window, event)
+  else:
+    handleMouseMove(window, event.locationInWindow)
 
 proc mouseDragged(self: ID, cmd: SEL, event: NSEvent): ID {.cdecl.} =
   mouseMoved(self, cmd, event)
@@ -983,6 +1037,7 @@ proc swapBuffers*(window: Window) =
     window.inner.contentView.NSOpenGLView.openGLContext.flushBuffer()
 
 proc close*(window: Window) =
+  window.releaseMouse()
   window.onCloseRequest = nil
   window.onFrame = nil
   window.onMove = nil

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -672,6 +672,60 @@ proc `cursor=`*(window: Window, cursor: Cursor) =
   else:
     discard SetCursor(window.customCursor)
 
+proc mouseCaptured*(window: Window): bool =
+  ## Returns true when the mouse is captured for relative look.
+  window.state.mouseCaptured
+
+proc centerCursor(window: Window) =
+  var rect: RECT
+  discard GetClientRect(window.hWnd, rect.addr)
+  var center = POINT(
+    x: (rect.right - rect.left) div 2,
+    y: (rect.bottom - rect.top) div 2
+  )
+  discard ClientToScreen(window.hWnd, center.addr)
+  discard SetCursorPos(center.x, center.y)
+  window.state.mousePos = ivec2(
+    (rect.right - rect.left) div 2,
+    (rect.bottom - rect.top) div 2
+  )
+  window.state.mousePrevPos = window.state.mousePos
+
+proc clipCursorToWindow(window: Window) =
+  var rect: RECT
+  discard GetClientRect(window.hWnd, rect.addr)
+  var
+    topLeft = POINT(x: rect.left, y: rect.top)
+    bottomRight = POINT(x: rect.right, y: rect.bottom)
+  discard ClientToScreen(window.hWnd, topLeft.addr)
+  discard ClientToScreen(window.hWnd, bottomRight.addr)
+  rect = RECT(
+    left: topLeft.x,
+    top: topLeft.y,
+    right: bottomRight.x,
+    bottom: bottomRight.y
+  )
+  discard ClipCursor(rect.addr)
+
+proc captureMouse*(window: Window) =
+  ## Hide the cursor and report unbounded relative mouse deltas.
+  if window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = true
+  while ShowCursor(0) >= 0:
+    discard
+  window.clipCursorToWindow()
+  window.centerCursor()
+
+proc releaseMouse*(window: Window) =
+  ## Show the cursor and restore normal absolute mouse tracking.
+  if not window.state.mouseCaptured:
+    return
+  window.state.mouseCaptured = false
+  discard ClipCursor(nil)
+  while ShowCursor(1) < 0:
+    discard
+
 proc url*(window: Window): string =
   ## Url cannot be gotten on windows.
   warn "Url cannot be gotten on windows"
@@ -885,6 +939,8 @@ proc wndProc(
     return 0
   of WM_SETFOCUS, WM_KILLFOCUS:
     clearButtonsTemplate()
+    if uMsg == WM_KILLFOCUS:
+      window.releaseMouse()
     if window.onFocusChange != nil:
       window.onFocusChange()
     return 0
@@ -911,6 +967,8 @@ proc wndProc(
       window.state.mousePos - window.state.mousePrevPos
     if window.onMouseMove != nil:
       window.onMouseMove()
+    if window.state.mouseCaptured:
+      window.centerCursor()
     if not window.trackMouseEventRegistered:
       var tme: TRACKMOUSEEVENTSTRUCT
       tme.cbSize = sizeof(TRACKMOUSEEVENTSTRUCT).DWORD

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -784,6 +784,15 @@ proc GetCursorPos*(
   lpPoint: LPPOINT
 ): BOOL {.dynlib: "User32".}
 
+proc SetCursorPos*(
+  x: int32,
+  y: int32
+): BOOL {.dynlib: "User32".}
+
+proc ShowCursor*(bShow: BOOL): int32 {.dynlib: "User32".}
+
+proc ClipCursor*(lpRect: LPRECT): BOOL {.dynlib: "User32".}
+
 proc TrackMouseEvent*(
   lpEventTrack: LPTRACKMOUSEEVENTSTRUCT
 ): BOOL {.dynlib: "User32".}


### PR DESCRIPTION
## Summary
- Add `captureMouse`, `releaseMouse`, and `mouseCaptured` for relative look-style input
- Implement capture on macOS (CGAssociate + cursor hide/warp) and Win32 (ClipCursor + ShowCursor)
- Stub the API on Linux and Emscripten with warnings for now

## Test plan
- [ ] On macOS, call `captureMouse` and confirm cursor hides and `mouseDelta` reports unbounded relative motion
- [ ] Call `releaseMouse` (and alt-tab / focus loss) and confirm cursor returns and absolute tracking resumes
- [ ] On Win32, verify clip/hide behavior and recenter while captured
- [ ] On Linux/Emscripten, confirm API exists and warns that capture is not implemented yet


Made with [Cursor](https://cursor.com)