### PR TITLE
Add native open and save file dialogs

### DIFF
--- a/examples/filedialogs.nim
+++ b/examples/filedialogs.nim
@@ -1,0 +1,27 @@
+## Demonstrates windy open/save file dialogs.
+import windy
+
+let window = newWindow("File Dialogs", ivec2(640, 360))
+window.makeContextCurrent()
+
+window.onFrame = proc() =
+  if window.buttonPressed[KeyO]:
+    let path = openFileDialog(
+      "Open File",
+      @[FileDialogFilter(name: "Text", extensions: "*.txt;*.md")],
+      ""
+    )
+    echo "open: ", path
+  if window.buttonPressed[KeyS]:
+    let path = saveFileDialog(
+      "Save File",
+      @[FileDialogFilter(name: "Text", extensions: "*.txt")],
+      "",
+      "untitled.txt"
+    )
+    echo "save: ", path
+  if window.buttonPressed[KeyEscape]:
+    window.closeRequested = true
+
+while not window.closeRequested:
+  pollEvents()

--- a/src/windy/common.nim
+++ b/src/windy/common.nim
@@ -62,6 +62,12 @@ type
   ClipboardContentKind* = enum
     TextContent, ImageContent
 
+  FileDialogFilter* = object
+    ## One named group of extensions for open/save dialogs.
+    ## Use extensions like "*.vox;*.qb" or "vox,qb".
+    name*: string
+    extensions*: string
+
   MSAA* = enum
     msaaDisabled = 0, msaa2x = 2, msaa4x = 4, msaa8x = 8
 

--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -1002,3 +1002,29 @@ proc openTempTextFile*(title, text: string) =
 proc openUrl*(url: string) =
   ## Open a URL in a new browser tab.
   open_url(url.cstring)
+
+proc openFileDialog*(
+  title = "Open File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = ""
+): string =
+  ## File dialogs are not available on Emscripten.
+  discard title
+  discard filters
+  discard defaultPath
+  warn("openFileDialog is not supported on emscripten")
+  result = ""
+
+proc saveFileDialog*(
+  title = "Save File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = "",
+  defaultName = ""
+): string =
+  ## File dialogs are not available on Emscripten.
+  discard title
+  discard filters
+  discard defaultPath
+  discard defaultName
+  warn("saveFileDialog is not supported on emscripten")
+  result = ""

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -1,5 +1,5 @@
 import
-  std/[os, sequtils, sets, strformat, strutils, times, unicode, uri, pathnorm],
+  std/[os, osproc, sequtils, sets, strformat, strutils, times, unicode, uri, pathnorm],
   ../../[common, internal],
   vmath, pixie,
   x11/[glx, keysym, x, xevent, xlib, xcursor]
@@ -1383,3 +1383,52 @@ proc openTempTextFile*(title, text: string) =
     createDir("tmp")
   writeFile("tmp/" & title, text)
   discard execShellCmd("xdg-open tmp/" & title)
+
+proc runZenity(args: seq[string]): string =
+  ## Runs zenity and returns stdout, or "" on cancel/error.
+  try:
+    let output = execProcess(
+      "zenity",
+      args = args,
+      options = {poUsePath, poStdErrToStdOut}
+    )
+    result = output.strip()
+  except OSError, IOError:
+    result = ""
+
+proc openFileDialog*(
+  title = "Open File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = ""
+): string =
+  ## Shows a zenity open-file dialog. Returns "" if canceled.
+  var args = @["--file-selection", "--title=" & title]
+  if defaultPath.len > 0:
+    args.add("--filename=" & defaultPath)
+  for filter in filters:
+    args.add("--file-filter=" & filter.name & " | " &
+      filter.extensions.replace(";", " ").replace(",", " "))
+  result = runZenity(args)
+
+proc saveFileDialog*(
+  title = "Save File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = "",
+  defaultName = ""
+): string =
+  ## Shows a zenity save-file dialog. Returns "" if canceled.
+  var args = @["--file-selection", "--save", "--confirm-overwrite",
+    "--title=" & title]
+  let startPath =
+    if defaultPath.len > 0 and defaultName.len > 0:
+      defaultPath / defaultName
+    elif defaultName.len > 0:
+      defaultName
+    else:
+      defaultPath
+  if startPath.len > 0:
+    args.add("--filename=" & startPath)
+  for filter in filters:
+    args.add("--file-filter=" & filter.name & " | " &
+      filter.extensions.replace(";", " ").replace(",", " "))
+  result = runZenity(args)

--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -72,6 +72,10 @@ type
   NSTextInputClient* = distinct int
   NSBitmapImageRep* = distinct NSObject
   NSDictionary* = distinct NSObject
+  NSOpenPanel* = distinct NSObject
+  NSSavePanel* = distinct NSObject
+  NSURL* = distinct NSObject
+  NSFileManager* = distinct NSObject
 
 const
   NSNotFound* = int.high
@@ -115,6 +119,7 @@ const
   NSBitmapImageFileTypePNG* = 4.NSBitmapImageFileType
   NSNormalWindowLevel* = 0.NSWindowLevel
   NSFloatingWindowLevel* = 3.NSWindowLevel
+  NSModalResponseOK* = 1
 
 type
   NSEventType* = enum
@@ -163,7 +168,39 @@ objc:
   proc array*(class: typedesc[NSArray]): NSArray
   proc count*(self: NSArray): uint
   proc objectAtIndex*(self: NSArray, x: uint): ID
+  proc firstObject*(self: NSArray): ID
   proc containsObject*(self: NSArray, x: ID): bool
+  proc componentsSeparatedByString*(self: NSString, x: NSString): NSArray
+  proc openPanel*(class: typedesc[NSOpenPanel]): NSOpenPanel
+  proc savePanel*(class: typedesc[NSSavePanel]): NSSavePanel
+  proc setCanChooseFiles*(self: NSOpenPanel, x: bool)
+  proc setCanChooseDirectories*(self: NSOpenPanel, x: bool)
+  proc setAllowsMultipleSelection*(self: NSOpenPanel, x: bool)
+  proc setCanCreateDirectories*(self: NSSavePanel, x: bool)
+  proc setTitle*(self: NSOpenPanel, x: NSString)
+  proc setTitle*(self: NSSavePanel, x: NSString)
+  proc setNameFieldStringValue*(self: NSSavePanel, x: NSString)
+  proc setDirectoryURL*(self: NSOpenPanel, x: NSURL)
+  proc setDirectoryURL*(self: NSSavePanel, x: NSURL)
+  proc setAllowedFileTypes*(self: NSOpenPanel, x: NSArray)
+  proc setAllowedFileTypes*(self: NSSavePanel, x: NSArray)
+  proc runModal*(self: NSOpenPanel): int
+  proc runModal*(self: NSSavePanel): int
+  proc URLs*(self: NSOpenPanel): NSArray
+  proc URL*(self: NSSavePanel): NSURL
+  proc path*(self: NSURL): NSString
+  proc fileURLWithPath*(
+    class: typedesc[NSURL],
+    x: NSString,
+    isDirectory: bool
+  ): NSURL
+  proc stringByDeletingLastPathComponent*(self: NSString): NSString
+  proc fileExistsAtPath*(
+    self: NSFileManager,
+    x: NSString,
+    isDirectory: ptr bool
+  ): bool
+  proc defaultManager*(class: typedesc[NSFileManager]): NSFileManager
   proc screens*(class: typedesc[NSScreen]): NSArray
   proc frame*(self: NSScreen): NSRect
   proc frame*(self: NSWindow): NSRect

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1,5 +1,5 @@
 import
-  std/[os, times, unicode, pathnorm],
+  std/[os, strutils, times, unicode, pathnorm],
   pixie/fileformats/png, pixie/images, utils, vmath,
   ../../[common, internal], macdefs
 
@@ -1373,3 +1373,89 @@ proc openTempTextFile*(title, text: string) =
 proc openUrl*(url: string) =
   ## Open a URL in the default web browser.
   discard execShellCmd("open " & url)
+
+proc fileDialogExtensions(filters: seq[FileDialogFilter]): seq[string] =
+  ## Collects unique file extensions without wildcards or dots.
+  for filter in filters:
+    for part in filter.extensions.split({';', ','}):
+      var ext = part.strip()
+      while ext.startsWith("*"):
+        ext.removePrefix("*")
+      while ext.startsWith("."):
+        ext.removePrefix(".")
+      if ext.len > 0 and ext != "*" and ext notin result:
+        result.add(ext)
+
+proc directoryURLForDialog(path: string): NSURL =
+  ## Returns a directory URL for dialogs, using the parent if needed.
+  if path.len == 0:
+    return 0.NSURL
+  var dirPath = path
+  var isDir = false
+  let exists = NSFileManager.defaultManager().fileExistsAtPath(
+    @dirPath,
+    isDir.addr
+  )
+  if exists and not isDir:
+    dirPath = $((@dirPath).stringByDeletingLastPathComponent())
+  result = NSURL.fileURLWithPath(@dirPath, true)
+
+proc allowedFileTypes(filters: seq[FileDialogFilter]): NSArray =
+  ## Builds an NSArray of allowed file extensions for panels.
+  let exts = fileDialogExtensions(filters)
+  if exts.len == 0:
+    return 0.NSArray
+  result = (@(exts.join(","))).componentsSeparatedByString(@",")
+
+proc openFileDialog*(
+  title = "Open File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = ""
+): string =
+  ## Shows a native open-file dialog. Returns "" if canceled.
+  init()
+  result = ""
+  autoreleasepool:
+    let panel = NSOpenPanel.openPanel()
+    panel.setCanChooseFiles(true)
+    panel.setCanChooseDirectories(false)
+    panel.setAllowsMultipleSelection(false)
+    panel.setTitle(@title)
+    let dirUrl = directoryURLForDialog(defaultPath)
+    if dirUrl.int != 0:
+      panel.setDirectoryURL(dirUrl)
+    let types = allowedFileTypes(filters)
+    if types.int != 0:
+      panel.setAllowedFileTypes(types)
+    if panel.runModal() == NSModalResponseOK:
+      let urls = panel.URLs()
+      if urls.int != 0 and urls.count > 0:
+        let url = urls.firstObject().NSURL
+        if url.int != 0:
+          result = $url.path()
+
+proc saveFileDialog*(
+  title = "Save File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = "",
+  defaultName = ""
+): string =
+  ## Shows a native save-file dialog. Returns "" if canceled.
+  init()
+  result = ""
+  autoreleasepool:
+    let panel = NSSavePanel.savePanel()
+    panel.setCanCreateDirectories(true)
+    panel.setTitle(@title)
+    if defaultName.len > 0:
+      panel.setNameFieldStringValue(@defaultName)
+    let dirUrl = directoryURLForDialog(defaultPath)
+    if dirUrl.int != 0:
+      panel.setDirectoryURL(dirUrl)
+    let types = allowedFileTypes(filters)
+    if types.int != 0:
+      panel.setAllowedFileTypes(types)
+    if panel.runModal() == NSModalResponseOK:
+      let url = panel.URL()
+      if url.int != 0:
+        result = $url.path()

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -1422,6 +1422,118 @@ proc alertDialog*(title, message: string) =
     0
   )
 
+proc fileDialogExtensions(filters: seq[FileDialogFilter]): seq[string] =
+  ## Collects unique file extensions without wildcards or dots.
+  for filter in filters:
+    for part in filter.extensions.split({';', ','}):
+      var ext = part.strip()
+      while ext.startsWith("*"):
+        ext.removePrefix("*")
+      while ext.startsWith("."):
+        ext.removePrefix(".")
+      if ext.len > 0 and ext != "*" and ext notin result:
+        result.add(ext)
+
+proc windowsFilterString(filters: seq[FileDialogFilter]): string =
+  ## Builds a Windows double-null-terminated ANSI filter string.
+  if filters.len == 0:
+    return "All Files\0*.*\0\0"
+  for filter in filters:
+    var patterns: seq[string]
+    for part in filter.extensions.split({';', ','}):
+      var ext = part.strip()
+      if ext.len == 0:
+        continue
+      if not ext.startsWith("*"):
+        if ext.startsWith("."):
+          ext = "*" & ext
+        else:
+          ext = "*." & ext
+      patterns.add(ext)
+    if patterns.len == 0:
+      patterns.add("*.*")
+    result.add(filter.name)
+    result.add('\0')
+    result.add(patterns.join(";"))
+    result.add('\0')
+  result.add('\0')
+
+proc openFileDialog*(
+  title = "Open File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = ""
+): string =
+  ## Shows a native open-file dialog. Returns "" if canceled.
+  init()
+  var
+    ofn: OPENFILENAMEW
+    buf = newSeq[WCHAR](4096)
+  let
+    titleW = title.wstr()
+    filterA = windowsFilterString(filters)
+    filterW = filterA.wstr()
+    dirW =
+      if defaultPath.len > 0:
+        defaultPath.wstr()
+      else:
+        ""
+  ofn.lStructSize = sizeof(ofn).DWORD
+  ofn.lpstrFilter = cast[LPCWSTR](filterW[0].addr)
+  ofn.lpstrFile = addr buf[0]
+  ofn.nMaxFile = buf.len.DWORD
+  ofn.lpstrTitle = cast[LPCWSTR](titleW[0].addr)
+  ofn.Flags = OFN_FILEMUSTEXIST or OFN_PATHMUSTEXIST or
+    OFN_EXPLORER or OFN_NOCHANGEDIR
+  if dirW.len > 0:
+    ofn.lpstrInitialDir = cast[LPCWSTR](dirW[0].addr)
+  if GetOpenFileNameW(ofn.addr) != 0:
+    result = $(addr buf[0])
+
+proc saveFileDialog*(
+  title = "Save File",
+  filters: seq[FileDialogFilter] = @[],
+  defaultPath = "",
+  defaultName = ""
+): string =
+  ## Shows a native save-file dialog. Returns "" if canceled.
+  init()
+  var
+    ofn: OPENFILENAMEW
+    buf = newSeq[WCHAR](4096)
+  if defaultName.len > 0:
+    let nameW = defaultName.wstr()
+    let bytes = min(nameW.len, (buf.len - 1) * sizeof(WCHAR))
+    if bytes > 0:
+      copyMem(buf[0].addr, nameW[0].addr, bytes)
+  let
+    titleW = title.wstr()
+    filterA = windowsFilterString(filters)
+    filterW = filterA.wstr()
+    dirW =
+      if defaultPath.len > 0:
+        defaultPath.wstr()
+      else:
+        ""
+    exts = fileDialogExtensions(filters)
+    defExtW =
+      if exts.len > 0:
+        exts[0].wstr()
+      else:
+        ""
+  ofn.lStructSize = sizeof(ofn).DWORD
+  ofn.lpstrFilter = cast[LPCWSTR](filterW[0].addr)
+  ofn.lpstrFile = addr buf[0]
+  ofn.nMaxFile = buf.len.DWORD
+  ofn.lpstrTitle = cast[LPCWSTR](titleW[0].addr)
+  ofn.Flags = OFN_OVERWRITEPROMPT or OFN_PATHMUSTEXIST or
+    OFN_EXPLORER or OFN_NOCHANGEDIR
+  if dirW.len > 0:
+    ofn.lpstrInitialDir = cast[LPCWSTR](dirW[0].addr)
+  if defExtW.len > 0:
+    ofn.lpstrDefExt = cast[LPCWSTR](defExtW[0].addr)
+  if GetSaveFileNameW(ofn.addr) != 0:
+    result = $(addr buf[0])
+
 proc getAvailableClipboardFormats(): seq[UINT] =
   var format = 0.UINT
   while true:

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -1156,4 +1156,45 @@ proc CloseHandle*(
   hObject: HANDLE
 ): BOOL {.dynlib: "kernel32".}
 
+type
+  OPENFILENAMEW* {.pure.} = object
+    lStructSize*: DWORD
+    hwndOwner*: HWND
+    hInstance*: HINSTANCE
+    lpstrFilter*: LPCWSTR
+    lpstrCustomFilter*: LPWSTR
+    nMaxCustFilter*: DWORD
+    nFilterIndex*: DWORD
+    lpstrFile*: LPWSTR
+    nMaxFile*: DWORD
+    lpstrFileTitle*: LPWSTR
+    nMaxFileTitle*: DWORD
+    lpstrInitialDir*: LPCWSTR
+    lpstrTitle*: LPCWSTR
+    Flags*: DWORD
+    nFileOffset*: WORD
+    nFileExtension*: WORD
+    lpstrDefExt*: LPCWSTR
+    lCustData*: LPARAM
+    lpfnHook*: pointer
+    lpTemplateName*: LPCWSTR
+    pvReserved*: pointer
+    dwReserved*: DWORD
+    FlagsEx*: DWORD
+
+const
+  OFN_OVERWRITEPROMPT* = 0x00000002.DWORD
+  OFN_NOCHANGEDIR* = 0x00000008.DWORD
+  OFN_PATHMUSTEXIST* = 0x00000800.DWORD
+  OFN_FILEMUSTEXIST* = 0x00001000.DWORD
+  OFN_EXPLORER* = 0x00080000.DWORD
+
+proc GetOpenFileNameW*(
+  ofn: ptr OPENFILENAMEW
+): BOOL {.dynlib: "Comdlg32", importc.}
+
+proc GetSaveFileNameW*(
+  ofn: ptr OPENFILENAMEW
+): BOOL {.dynlib: "Comdlg32", importc.}
+
 {.pop.}


### PR DESCRIPTION
## Summary
- Adds `openFileDialog` and `saveFileDialog` with optional filters and default paths.
- Implements native dialogs on macOS (`NSOpenPanel`/`NSSavePanel`), Windows (`GetOpenFileNameW`/`GetSaveFileNameW`), and Linux (zenity).
- Emscripten stubs return empty string; includes `examples/filedialogs.nim`.

## Test plan
- [ ] Run `nim c examples/filedialogs.nim` and press O/S to open/save on macOS
- [ ] Confirm cancel returns `""`
- [ ] Spot-check filters (`*.txt`, etc.)
- [ ] Windows/Linux smoke if available


Made with [Cursor](https://cursor.com)