### PR TITLE
Add macOS alertDialog via NSAlert

### DIFF
--- a/examples/alertdialog.nim
+++ b/examples/alertdialog.nim
@@ -1,0 +1,5 @@
+## Demonstrates windy alertDialog.
+import windy
+
+alertDialog("Windy Alert", "macOS NSAlert is working.")
+echo "alert closed"

--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -74,6 +74,7 @@ type
   NSDictionary* = distinct NSObject
   NSOpenPanel* = distinct NSObject
   NSSavePanel* = distinct NSObject
+  NSAlert* = distinct NSObject
   NSURL* = distinct NSObject
   NSFileManager* = distinct NSObject
 
@@ -186,6 +187,9 @@ objc:
   proc setAllowedFileTypes*(self: NSSavePanel, x: NSArray)
   proc runModal*(self: NSOpenPanel): int
   proc runModal*(self: NSSavePanel): int
+  proc setMessageText*(self: NSAlert, x: NSString)
+  proc setInformativeText*(self: NSAlert, x: NSString)
+  proc runModal*(self: NSAlert): int
   proc URLs*(self: NSOpenPanel): NSArray
   proc URL*(self: NSSavePanel): NSURL
   proc path*(self: NSURL): NSString

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1407,6 +1407,15 @@ proc allowedFileTypes(filters: seq[FileDialogFilter]): NSArray =
     return 0.NSArray
   result = (@(exts.join(","))).componentsSeparatedByString(@",")
 
+proc alertDialog*(title, message: string) =
+  ## Pops a blocking alert dialog.
+  init()
+  autoreleasepool:
+    let alert = NSAlert.new()
+    alert.setMessageText(@title)
+    alert.setInformativeText(@message)
+    discard alert.runModal()
+
 proc openFileDialog*(
   title = "Open File",
   filters: seq[FileDialogFilter] = @[],


### PR DESCRIPTION
## Summary
- Expose `alertDialog(title, message)` on macOS using AppKit `NSAlert`, matching the existing Windows API.
- Add `NSAlert` bindings in `macdefs.nim` and a small `examples/alertdialog.nim` smoke example.

## Test plan
- [x] `nim r examples/alertdialog.nim` on macOS shows a native alert and continues after OK
- [ ] Confirm Windows `alertDialog` still builds/unchanged
- [ ] Optional: call `alertDialog` from an app after Steam/sound init failure on Mac


Made with [Cursor](https://cursor.com)