### PR TITLE
Read PNG clipboard images, stub other platforms

### DIFF
--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -473,6 +473,14 @@ proc getClipboardString*(): string =
     "getClipboardString is not supported on emscripten"
   )
 
+proc getClipboardContentKinds*(): set[ClipboardContentKind] =
+  ## Image clipboard is not implemented on Emscripten yet.
+  discard
+
+proc getClipboardImage*(): Image =
+  ## Image clipboard is not implemented on Emscripten yet.
+  nil
+
 proc closeIme*(window: Window) =
   if window.state.imeCompositionString.len > 0:
     window.state.imeCompositionString = ""

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -1293,6 +1293,14 @@ proc setClipboardString*(s: string) =
   clipboardContent = s
   display.XSetSelectionOwner(xaClipboard, clipboardWindow)
 
+proc getClipboardContentKinds*(): set[ClipboardContentKind] =
+  ## Image clipboard is not implemented on X11 yet.
+  discard
+
+proc getClipboardImage*(): Image =
+  ## Image clipboard is not implemented on X11 yet.
+  nil
+
 proc pollEvents*() =
   for window in windows:
     if window.onFrame != nil:

--- a/src/windy/platforms/macos/macdefs.nim
+++ b/src/windy/platforms/macos/macdefs.nim
@@ -141,6 +141,7 @@ var
   NSApp* {.importc.}: NSApplication
   NSPasteboardTypeString* {.importc.}: NSPasteboardType
   NSPasteboardTypeTIFF* {.importc.}: NSPasteboardType
+  NSPasteboardTypePNG* {.importc.}: NSPasteboardType
   NSFilenamesPboardType* {.importc.}: NSPasteboardType
   NSDefaultRunLoopMode* {.importc.}: NSRunLoopMode
 

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1305,10 +1305,12 @@ proc getClipboardContentKinds*(): set[ClipboardContentKind] =
 
     if types.containsObject(NSPasteboardTypeString.ID):
       result.incl TextContent
-    if types.containsObject(NSPasteboardTypeTIFF.ID):
+    if types.containsObject(NSPasteboardTypePNG.ID) or
+        types.containsObject(NSPasteboardTypeTIFF.ID):
       result.incl ImageContent
 
 proc getClipboardImage*(): Image =
+  ## Reads a PNG or TIFF image from the system pasteboard.
   init()
   autoreleasepool:
     let
@@ -1317,6 +1319,14 @@ proc getClipboardImage*(): Image =
 
     if types.int == 0:
       return
+
+    if types.containsObject(NSPasteboardTypePNG.ID):
+      let data = pboard.dataForType(NSPasteboardTypePNG)
+      if data.int != 0:
+        try:
+          return decodePng(data.bytes, data.length.int).convertToImage()
+        except:
+          discard
 
     if not types.containsObject(NSPasteboardTypeTIFF.ID):
       return


### PR DESCRIPTION
## Summary
- macOS `getClipboardImage` / `getClipboardContentKinds` now accept **PNG** as well as TIFF (screenshots and many apps provide both).
- Add no-op `getClipboardImage` / `getClipboardContentKinds` stubs on **Linux (X11)** and **Emscripten** so the API is available on every backend (Windows already had full support).

## Test plan
- [ ] On macOS: copy a screenshot to the clipboard (Cmd+Ctrl+Shift+4), run a small snippet that calls `getClipboardContentKinds()` and `getClipboardImage()`, confirm non-nil image with expected size
- [ ] On macOS: copy plain text only, confirm `ImageContent` is absent and `getClipboardImage()` returns nil
- [ ] Linux/Emscripten still compile with the new stubs

Made with [Cursor](https://cursor.com)