### PR TITLE
Change window frame synchronization without affecting other windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         Invoke-WebRequest https://github.com/pal1000/mesa-dist-win/releases/download/26.2.0/mesa3d-26.2.0-release-msvc.7z -OutFile "$env:RUNNER_TEMP/mesa.7z"
         7z x "$env:RUNNER_TEMP/mesa.7z" "-o$env:RUNNER_TEMP/mesa"
         Copy-Item "$env:RUNNER_TEMP/mesa/x64/*.dll" tests/
-        nim r --parallelBuild:1 tests/test_vsync.nim
+        nim r --parallelBuild:1 --out:tests/test_vsync.exe tests/test_vsync.nim
 
     # Build native examples.
     - run: nim c examples/basic.nim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,24 @@ jobs:
     - run: nim r -d:useCpu tests/test_cpu_pixels.nim
       if: matrix.os == 'windows-latest'
 
+    - run: nim r --parallelBuild:1 tests/test_vsync.nim
+      if: matrix.os == 'macos-latest'
+    - run: nim r --parallelBuild:1 -d:useCpu tests/test_vsync.nim
+      if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+    - run: LIBGL_ALWAYS_SOFTWARE=1 xvfb-run -a nim r --parallelBuild:1 tests/test_vsync.nim
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Test Windows OpenGL with Mesa
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      env:
+        GALLIUM_DRIVER: llvmpipe
+      run: |
+        Invoke-WebRequest https://github.com/pal1000/mesa-dist-win/releases/download/26.2.0/mesa3d-26.2.0-release-msvc.7z -OutFile "$env:RUNNER_TEMP/mesa.7z"
+        7z x "$env:RUNNER_TEMP/mesa.7z" "-o$env:RUNNER_TEMP/mesa"
+        Copy-Item "$env:RUNNER_TEMP/mesa/x64/*.dll" tests/
+        nim r --parallelBuild:1 tests/test_vsync.nim
+
     # Build native examples.
     - run: nim c examples/basic.nim
     - run: nim c examples/basic_boxy.nim

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -47,6 +47,7 @@ type
     innerDecorated: bool
     innerFocused: bool
     mouseCaptured: bool
+    vsyncEnabled: bool
 
     # XDnD state
     xdndSource: XWindow
@@ -405,6 +406,34 @@ proc makeContextCurrent*(window: Window) =
 
 proc swapBuffers*(window: Window) =
   display.glXSwapBuffers(window.handle)
+
+proc applyVsync(window: Window, enabled: bool) =
+  window.makeContextCurrent()
+  let interval = if enabled: 1.cint else: 0.cint
+  if glXSwapIntervalEXT != nil:
+    display.glXSwapIntervalEXT(window.handle, interval)
+  elif glXSwapIntervalMESA != nil:
+    if glXSwapIntervalMESA(interval) != 0:
+      raise WindyError.newException("Error setting the GLX swap interval")
+  elif glXSwapIntervalSGI != nil:
+    if not enabled:
+      raise WindyError.newException(
+        "Disabling VSync is not supported by GLX_SGI_swap_control"
+      )
+    if glXSwapIntervalSGI(interval) != 0:
+      raise WindyError.newException("Error setting the GLX swap interval")
+  else:
+    raise WindyError.newException("VSync control is not supported")
+  window.vsyncEnabled = enabled
+
+proc vsync*(window: Window): bool =
+  ## Returns true when vertical sync is enabled for this window.
+  window.vsyncEnabled
+
+proc `vsync=`*(window: Window, enabled: bool) =
+  ## Changes the GLX swap interval without recreating the window.
+  if window.vsyncEnabled != enabled:
+    window.applyVsync(enabled)
 
 template blockUntil(expression: untyped) {.dirty.} =
   ## In X11 many properties are async, you change them and then it takes
@@ -819,15 +848,7 @@ proc newWindow*(
 
   makeContextCurrent result
 
-  if vsync:
-    if glXSwapIntervalEXT != nil:
-      display.glXSwapIntervalEXT(result.handle, 1)
-    elif glXSwapIntervalMESA != nil:
-      glXSwapIntervalMESA(1)
-    elif glXSwapIntervalSGI != nil:
-      glXSwapIntervalSGI(1)
-    else:
-      raise WindyError.newException("VSync is not supported")
+  result.applyVsync(vsync)
 
   if visible:
     result.visible = true

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -408,32 +408,45 @@ proc swapBuffers*(window: Window) =
   display.glXSwapBuffers(window.handle)
 
 proc applyVsync(window: Window, enabled: bool) =
-  window.makeContextCurrent()
-  let interval = if enabled: 1.cint else: 0.cint
-  if glXSwapIntervalEXT != nil:
+  let
+    extensions = strutils.splitWhitespace($display.glXQueryExtensionsString(display.defaultScreen))
+    interval = if enabled: 1.cint else: 0.cint
+  if "GLX_EXT_swap_control" in extensions:
     display.glXSwapIntervalEXT(window.handle, interval)
-  elif glXSwapIntervalMESA != nil:
-    if glXSwapIntervalMESA(interval) != 0:
+    var actual: cuint
+    display.glXQueryDrawable(window.handle, 0x20F1, actual.addr)
+    if actual != interval.cuint:
       raise WindyError.newException("Error setting the GLX swap interval")
-  elif glXSwapIntervalSGI != nil:
-    if not enabled:
-      raise WindyError.newException(
-        "Disabling VSync is not supported by GLX_SGI_swap_control"
-      )
-    if glXSwapIntervalSGI(interval) != 0:
-      raise WindyError.newException("Error setting the GLX swap interval")
-  else:
+  elif "GLX_MESA_swap_control" in extensions or "GLX_SGI_swap_control" in extensions:
+    let
+      previousDisplay = glXGetCurrentDisplay()
+      previousDraw = glXGetCurrentDrawable()
+      previousRead = glXGetCurrentReadDrawable()
+      previousContext = glXGetCurrentContext()
+    window.makeContextCurrent()
+    defer:
+      discard glXMakeContextCurrent(
+        if previousDisplay == nil: display else: previousDisplay,
+        previousDraw, previousRead, previousContext)
+    if "GLX_MESA_swap_control" in extensions:
+      if glXSwapIntervalMESA(interval) != 0 or glXGetSwapIntervalMESA() != interval:
+        raise WindyError.newException("Error setting the GLX swap interval")
+    elif enabled:
+      if glXSwapIntervalSGI(interval) != 0:
+        raise WindyError.newException("Error setting the GLX swap interval")
+    elif window.vsyncEnabled:
+      raise WindyError.newException("GLX_SGI_swap_control cannot disable VSync")
+  elif enabled:
     raise WindyError.newException("VSync control is not supported")
   window.vsyncEnabled = enabled
 
 proc vsync*(window: Window): bool =
-  ## Returns true when vertical sync is enabled for this window.
+  ## Returns the last accepted interval. SGI cannot read its interval back.
   window.vsyncEnabled
 
 proc `vsync=`*(window: Window, enabled: bool) =
-  ## Changes the GLX swap interval without recreating the window.
-  if window.vsyncEnabled != enabled:
-    window.applyVsync(enabled)
+  ## Changes the GLX swap interval, preserving the caller's current context.
+  window.applyVsync(enabled)
 
 template blockUntil(expression: untyped) {.dirty.} =
   ## In X11 many properties are async, you change them and then it takes

--- a/src/windy/platforms/linux/x11/glx.nim
+++ b/src/windy/platforms/linux/x11/glx.nim
@@ -32,3 +32,13 @@ proc glXSwapIntervalEXT*(d: Display, drawable: Drawable,
     interval: cint) {.libglx.}
 proc glXSwapIntervalMESA*(interval: cint): cint {.libglx.}
 proc glXSwapIntervalSGI*(interval: cint): cint {.libglx.}
+
+proc glXGetCurrentDisplay*(): Display {.libglx.}
+proc glXGetCurrentDrawable*(): Drawable {.libglx.}
+proc glXGetCurrentReadDrawable*(): Drawable {.libglx.}
+proc glXMakeContextCurrent*(d: Display, draw, read: Drawable,
+    ctx: GlxContext): cint {.libglx.}
+proc glXQueryExtensionsString*(d: Display, screen: cint): cstring {.libglx.}
+proc glXQueryDrawable*(d: Display, drawable: Drawable,
+    attribute: cint, value: ptr cuint) {.libglx.}
+proc glXGetSwapIntervalMESA*(): cint {.libglx.}

--- a/src/windy/platforms/linux/x11/glx.nim
+++ b/src/windy/platforms/linux/x11/glx.nim
@@ -30,5 +30,5 @@ proc glXSwapBuffers*(d: Display, drawable: Drawable) {.libglx.}
 
 proc glXSwapIntervalEXT*(d: Display, drawable: Drawable,
     interval: cint) {.libglx.}
-proc glXSwapIntervalMESA*(interval: cint) {.libglx.}
-proc glXSwapIntervalSGI*(interval: cint) {.libglx.}
+proc glXSwapIntervalMESA*(interval: cint): cint {.libglx.}
+proc glXSwapIntervalSGI*(interval: cint): cint {.libglx.}

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -41,6 +41,7 @@ type
     minimizedState: bool
     cpuImage: NSImage
     activationSettlePolls: int
+    vsyncEnabled: bool
 
 const
   ActivationSettlePolls = 60
@@ -1090,6 +1091,23 @@ proc swapBuffers*(window: Window) =
   else:
     window.inner.contentView.NSOpenGLView.openGLContext.flushBuffer()
 
+proc vsync*(window: Window): bool =
+  ## Returns true when vertical sync is enabled for this window.
+  window.vsyncEnabled
+
+proc `vsync=`*(window: Window, enabled: bool) =
+  ## Changes the OpenGL swap interval without recreating the window.
+  if window.vsyncEnabled == enabled:
+    return
+  when not defined(useMetal4) and not defined(useCpu):
+    window.makeContextCurrent()
+    var swapInterval: GLint = if enabled: 1 else: 0
+    window.inner.contentView.NSOpenGLView.openGLContext.setValues(
+      swapInterval.addr,
+      NSOpenGLContextParameterSwapInterval
+    )
+  window.vsyncEnabled = enabled
+
 proc presentPixels*(window: Window, image: Image) =
   ## Presents a CPU-rendered Pixie image into the macOS window content view.
   when defined(useCpu):
@@ -1142,6 +1160,7 @@ proc newWindow*(
   stencilBits = 8
 ): Window =
   result = Window()
+  result.vsyncEnabled = vsync
 
   init()
 

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1092,21 +1092,25 @@ proc swapBuffers*(window: Window) =
     window.inner.contentView.NSOpenGLView.openGLContext.flushBuffer()
 
 proc vsync*(window: Window): bool =
-  ## Returns true when vertical sync is enabled for this window.
-  window.vsyncEnabled
+  ## Returns the OpenGL swap interval; other backends retain the constructor option.
+  when defined(useMetal4) or defined(useCpu):
+    window.vsyncEnabled
+  else:
+    var interval: GLint
+    window.inner.contentView.NSOpenGLView.openGLContext.getValues(
+      interval.addr, NSOpenGLContextParameterSwapInterval)
+    interval != 0
 
 proc `vsync=`*(window: Window, enabled: bool) =
-  ## Changes the OpenGL swap interval without recreating the window.
-  if window.vsyncEnabled == enabled:
-    return
-  when not defined(useMetal4) and not defined(useCpu):
-    window.makeContextCurrent()
-    var swapInterval: GLint = if enabled: 1 else: 0
+  ## Changes this window's OpenGL swap interval, preserving the current context.
+  when defined(useMetal4) or defined(useCpu):
+    raise WindyError.newException("The application controls VSync on this backend")
+  else:
+    var interval: GLint = if enabled: 1 else: 0
     window.inner.contentView.NSOpenGLView.openGLContext.setValues(
-      swapInterval.addr,
-      NSOpenGLContextParameterSwapInterval
-    )
-  window.vsyncEnabled = enabled
+      interval.addr, NSOpenGLContextParameterSwapInterval)
+    if window.vsync != enabled:
+      raise WindyError.newException("Error setting the OpenGL swap interval")
 
 proc presentPixels*(window: Window, image: Image) =
   ## Presents a CPU-rendered Pixie image into the macOS window content view.

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -1365,18 +1365,33 @@ proc title*(window: Window): string =
   window.state.title
 
 proc vsync*(window: Window): bool =
-  ## Returns true when vertical sync is enabled for this window.
-  window.vsyncEnabled
+  ## Returns the OpenGL swap interval; other backends retain the constructor option.
+  when defined(useDirectX) or defined(useVulkan) or defined(useCpu):
+    window.vsyncEnabled
+  else:
+    let previousDC = wglGetCurrentDC()
+    let previousContext = wglGetCurrentContext()
+    window.makeContextCurrent()
+    defer: makeContextCurrent(previousDC, previousContext)
+    let getInterval = cast[proc(): int32 {.stdcall, raises: [].}](
+      wglGetProcAddress("wglGetSwapIntervalEXT"))
+    if getInterval == nil:
+      raise WindyError.newException("VSync readback is not supported")
+    getInterval() != 0
 
 proc `vsync=`*(window: Window, enabled: bool) =
-  ## Changes the OpenGL swap interval without recreating the window.
-  if window.vsyncEnabled == enabled:
-    return
-  when not defined(useDirectX) and not defined(useVulkan) and not defined(useCpu):
+  ## Changes this window's OpenGL swap interval, preserving the current context.
+  when defined(useDirectX) or defined(useVulkan) or defined(useCpu):
+    raise WindyError.newException("The application controls VSync on this backend")
+  else:
+    let previousDC = wglGetCurrentDC()
+    let previousContext = wglGetCurrentContext()
     window.makeContextCurrent()
+    defer: makeContextCurrent(previousDC, previousContext)
     if wglSwapIntervalEXT(if enabled: 1 else: 0) == 0:
-      raise newException(WindyError, "Error setting swap interval")
-  window.vsyncEnabled = enabled
+      raise WindyError.newException("Error setting swap interval")
+    if window.vsync != enabled:
+      raise WindyError.newException("Error reading back the swap interval")
 
 proc icon*(window: Window): Image =
   window.state.icon

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -84,7 +84,7 @@ type
     hdc: HDC
     hglrc: HGLRC
     cpuPresentBuffer: seq[uint8]
-    vsync*: bool
+    vsyncEnabled: bool
     iconHandle: HICON
     customCursor: HCURSOR
 
@@ -1339,7 +1339,7 @@ proc newWindow*(
   result.title = title
   result.hWnd = createWindow(windowClassName, title)
   result.size = size
-  result.vsync = vsync
+  result.vsyncEnabled = vsync
 
   discard SetPropW(result.hWnd, cast[ptr WCHAR](windowPropKey[0].addr), 1)
 
@@ -1366,7 +1366,17 @@ proc title*(window: Window): string =
 
 proc vsync*(window: Window): bool =
   ## Returns true when vertical sync is enabled for this window.
-  window.vsync
+  window.vsyncEnabled
+
+proc `vsync=`*(window: Window, enabled: bool) =
+  ## Changes the OpenGL swap interval without recreating the window.
+  if window.vsyncEnabled == enabled:
+    return
+  when not defined(useDirectX) and not defined(useVulkan) and not defined(useCpu):
+    window.makeContextCurrent()
+    if wglSwapIntervalEXT(if enabled: 1 else: 0) == 0:
+      raise newException(WindyError, "Error setting swap interval")
+  window.vsyncEnabled = enabled
 
 proc icon*(window: Window): Image =
   window.state.icon

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,1 +1,5 @@
 import windy
+
+proc checkVsyncApi(window: Window) {.used.} =
+  window.vsync = false
+  discard window.vsync

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,5 +1,1 @@
 import windy
-
-proc checkVsyncApi(window: Window) {.used.} =
-  window.vsync = false
-  discard window.vsync

--- a/tests/test_vsync.nim
+++ b/tests/test_vsync.nim
@@ -1,0 +1,93 @@
+## Run with a native graphics session. -d:vsyncTiming prints swap timings.
+import windy
+
+when defined(useCpu) or defined(useMetal4) or defined(useDirectX) or defined(useVulkan):
+  let window = newWindow("VSync ownership", ivec2(160), visible = false)
+  let before = window.vsync
+  var rejected = false
+  try: window.vsync = not before
+  except WindyError: rejected = true
+  doAssert rejected and window.vsync == before
+  window.close()
+  echo "Application-owned presentation rejected the VSync change"
+elif defined(emscripten):
+  let window = newWindow("Browser VSync", ivec2(160))
+  for enabled in [false, true, false]:
+    window.vsync = enabled
+    doAssert window.vsync
+else:
+  import std/[importutils, monotimes, times]
+  import opengl
+  privateAccess(Window)
+  when defined(macosx):
+    import windy/platforms/macos/macdefs
+    {.passL: "-framework OpenGL".}
+    proc currentContext(): pointer {.importc: "CGLGetCurrentContext",
+      header: "<OpenGL/OpenGL.h>".}
+    proc readInterval(window: Window): int =
+      var value: int32
+      window.inner.contentView.NSOpenGLView.openGLContext.getValues(
+        value.addr, NSOpenGLContextParameterSwapInterval)
+      value.int
+  elif defined(windows):
+    import windy/platforms/win32/windefs
+    proc currentContext(): pointer {.stdcall, importc: "wglGetCurrentContext",
+      dynlib: "opengl32.dll".}
+    proc address(name: cstring): pointer {.stdcall, importc: "wglGetProcAddress",
+      dynlib: "opengl32.dll".}
+    proc readInterval(window: Window): int =
+      discard window
+      let getInterval = cast[proc(): int32 {.stdcall.}](address("wglGetSwapIntervalEXT"))
+      doAssert getInterval != nil
+      getInterval().int
+  else:
+    import std/strutils
+    import windy/platforms/linux/x11/[glx, xlib]
+    proc currentContext(): pointer = glXGetCurrentContext()
+    proc readInterval(window: Window): int =
+      let display = glXGetCurrentDisplay()
+      let extensions = strutils.splitWhitespace($display.glXQueryExtensionsString(display.defaultScreen))
+      if "GLX_EXT_swap_control" in extensions:
+        var value: cuint
+        display.glXQueryDrawable(window.handle, 0x20F1, value.addr)
+        value.int
+      elif "GLX_MESA_swap_control" in extensions:
+        glXGetSwapIntervalMESA().int
+      else: -1 # SGI and servers without swap control cannot read back.
+
+  let window = newWindow("VSync runtime test", ivec2(320, 200), vsync = false)
+  let peer = newWindow("VSync peer", ivec2(160), vsync = false)
+  for i in 0 ..< 60: pollEvents()
+  window.makeContextCurrent()
+  loadExtensions()
+  for enabled in [false, true, false]:
+    peer.makeContextCurrent()
+    let previous = currentContext()
+    try:
+      window.vsync = enabled
+    except WindyError:
+      doAssert currentContext() == previous
+      when defined(linux):
+        doAssert enabled or window.vsync, "initial disabled state must work"
+        echo "Driver cannot change VSync to ", enabled
+        continue
+      else: raise
+    doAssert currentContext() == previous, "VSync must preserve the peer context"
+    window.makeContextCurrent()
+    let interval = window.readInterval()
+    if interval >= 0:
+      doAssert (interval != 0) == enabled
+    doAssert window.vsync == enabled
+    let start = getMonoTime()
+    for frame in 0 ..< 30:
+      glClearColor(if enabled: 0.0 else: 0.6, 0.3, 0.5, 1)
+      glClear(GL_COLOR_BUFFER_BIT)
+      window.swapBuffers()
+      pollEvents()
+    when defined(vsyncTiming):
+      echo "vsync=", enabled, " driverInterval=", interval,
+        " swaps=30 elapsedMs=", (getMonoTime() - start).inMilliseconds
+    doAssert glGetError() == GL_NO_ERROR
+  peer.close()
+  window.close()
+  echo "VSync context, supported intervals, and unsupported-change checks passed"

--- a/tests/test_vsync.nim
+++ b/tests/test_vsync.nim
@@ -30,7 +30,6 @@ else:
         value.addr, NSOpenGLContextParameterSwapInterval)
       value.int
   elif defined(windows):
-    import windy/platforms/win32/windefs
     proc currentContext(): pointer {.stdcall, importc: "wglGetCurrentContext",
       dynlib: "opengl32.dll".}
     proc address(name: cstring): pointer {.stdcall, importc: "wglGetProcAddress",
@@ -68,7 +67,17 @@ else:
     except WindyError:
       doAssert currentContext() == previous
       when defined(linux):
-        doAssert enabled or window.vsync, "initial disabled state must work"
+        let display = glXGetCurrentDisplay()
+        let extensions = strutils.splitWhitespace(
+          $display.glXQueryExtensionsString(display.defaultScreen))
+        doAssert "GLX_EXT_swap_control" notin extensions and
+          "GLX_MESA_swap_control" notin extensions,
+          "a supported swap-control path must succeed"
+        if enabled:
+          doAssert "GLX_SGI_swap_control" notin extensions
+        else:
+          doAssert "GLX_SGI_swap_control" in extensions and window.vsync,
+            "initial disabled state must work"
         echo "Driver cannot change VSync to ", enabled
         continue
       else: raise


### PR DESCRIPTION
## Summary

Allow supported OpenGL windows to change synchronization with the display’s refresh rate (VSync) without recreating the window or switching another window’s rendering context. Report unsupported changes as errors. Platform support and remaining test gaps are listed below.

## Details

A game may need to change OpenGL VSync without recreating its window. The previous PR could switch the current rendering context, report a change on a backend it did not control, or call a GLX extension the server did not support.

The setter now preserves the caller’s context. macOS and Windows read the driver’s interval; Linux checks advertised extensions and verifies EXT/MESA readback. An initially disabled Linux window works without swap control. Unsupported enable requests raise an error; SGI cannot turn an already enabled interval off. CPU, Metal, DirectX, and Vulkan setters reject changes because the application owns presentation there. Browser VSync remains controlled by the browser.

Validation:

- On a native Mac, the old setter changed the peer window’s current context. The fixed test preserves it and reads intervals 0, 1, 0. On the final integrated tree, 30 rendered swaps took 33 ms, 311 ms, and 6 ms respectively.
- With Mesa/Xvfb, the old setter accepted an enable request despite the server advertising no swap-control extension. The fixed test creates a disabled window, rejects unsupported enable, and keeps the peer context. This server has no supported swap-control extension, so it does not validate EXT/MESA/SGI success or physical frame pacing.
- The native Mac CPU backend rejects changes without changing its reported option.
- A focused runtime test replaces the old compile-only API check. It is wired into existing Mac/Linux CI, Windows CPU CI, and a Windows OpenGL run using Mesa. The final hosted Windows OpenGL/Mesa test, Windows CPU test, Mac OpenGL/CPU tests, and Linux unsupported-extension test have passed; the complete final build matrix has also passed.

Physical Windows/Linux pacing, SGI/MESA success paths, and native non-CPU alternative backends still need runtime evidence. These limits are not covered by the Mac result.

[Current CI run](https://github.com/treeform/windy/actions/runs/34400594576) passed on Linux, macOS, and Windows. The runtime limits above still apply.

[Codex, acting on behalf of relh]
