### PR TITLE
Move Win32 file dialog defs into type, const, and proc sections

### DIFF
--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -219,6 +219,30 @@ type
   BITMAPINFO* {.pure.} = object
     bmiHeader*: BITMAPINFOHEADER
     bmiColors*: array[1, RGBQUAD]
+  OPENFILENAMEW* {.pure.} = object
+    lStructSize*: DWORD
+    hwndOwner*: HWND
+    hInstance*: HINSTANCE
+    lpstrFilter*: LPCWSTR
+    lpstrCustomFilter*: LPWSTR
+    nMaxCustFilter*: DWORD
+    nFilterIndex*: DWORD
+    lpstrFile*: LPWSTR
+    nMaxFile*: DWORD
+    lpstrFileTitle*: LPWSTR
+    nMaxFileTitle*: DWORD
+    lpstrInitialDir*: LPCWSTR
+    lpstrTitle*: LPCWSTR
+    Flags*: DWORD
+    nFileOffset*: WORD
+    nFileExtension*: WORD
+    lpstrDefExt*: LPCWSTR
+    lCustData*: LPARAM
+    lpfnHook*: pointer
+    lpTemplateName*: LPCWSTR
+    pvReserved*: pointer
+    dwReserved*: DWORD
+    FlagsEx*: DWORD
 
 type
   wglCreateContext* = proc(hdc: HDC): HGLRC {.stdcall, raises: [].}
@@ -565,6 +589,11 @@ const
   DIB_RGB_COLORS* = 0
   SRCCOPY* = 0x00CC0020
   GDI_ERROR* = -1
+  OFN_OVERWRITEPROMPT* = 0x00000002.DWORD
+  OFN_NOCHANGEDIR* = 0x00000008.DWORD
+  OFN_PATHMUSTEXIST* = 0x00000800.DWORD
+  OFN_FILEMUSTEXIST* = 0x00001000.DWORD
+  OFN_EXPLORER* = 0x00080000.DWORD
 
 {.push importc, stdcall.}
 
@@ -1156,45 +1185,12 @@ proc CloseHandle*(
   hObject: HANDLE
 ): BOOL {.dynlib: "kernel32".}
 
-type
-  OPENFILENAMEW* {.pure.} = object
-    lStructSize*: DWORD
-    hwndOwner*: HWND
-    hInstance*: HINSTANCE
-    lpstrFilter*: LPCWSTR
-    lpstrCustomFilter*: LPWSTR
-    nMaxCustFilter*: DWORD
-    nFilterIndex*: DWORD
-    lpstrFile*: LPWSTR
-    nMaxFile*: DWORD
-    lpstrFileTitle*: LPWSTR
-    nMaxFileTitle*: DWORD
-    lpstrInitialDir*: LPCWSTR
-    lpstrTitle*: LPCWSTR
-    Flags*: DWORD
-    nFileOffset*: WORD
-    nFileExtension*: WORD
-    lpstrDefExt*: LPCWSTR
-    lCustData*: LPARAM
-    lpfnHook*: pointer
-    lpTemplateName*: LPCWSTR
-    pvReserved*: pointer
-    dwReserved*: DWORD
-    FlagsEx*: DWORD
-
-const
-  OFN_OVERWRITEPROMPT* = 0x00000002.DWORD
-  OFN_NOCHANGEDIR* = 0x00000008.DWORD
-  OFN_PATHMUSTEXIST* = 0x00000800.DWORD
-  OFN_FILEMUSTEXIST* = 0x00001000.DWORD
-  OFN_EXPLORER* = 0x00080000.DWORD
-
 proc GetOpenFileNameW*(
   ofn: ptr OPENFILENAMEW
-): BOOL {.dynlib: "Comdlg32", importc.}
+): BOOL {.dynlib: "Comdlg32".}
 
 proc GetSaveFileNameW*(
   ofn: ptr OPENFILENAMEW
-): BOOL {.dynlib: "Comdlg32", importc.}
+): BOOL {.dynlib: "Comdlg32".}
 
 {.pop.}


### PR DESCRIPTION
## Summary
- Move `OPENFILENAMEW`, the `OFN_*` flags, and `GetOpenFileNameW` / `GetSaveFileNameW` into the existing type, const, and imported-proc sections in `windefs.nim`.
- Drop the extra `importc` on those two procs so they inherit `importc, stdcall` from the single file-wide push/pop, same as the other Win32 APIs.

## Test plan
- [x] `nim c examples/filedialogs.nim`, `examples/alertdialog.nim`, and `tests/test.nim`
- [x] Run `examples/filedialogs.exe`: O opens, S saves, cancel returns empty paths
- [x] Skim the `windefs.nim` section order (types, then consts, then one `importc` proc block)

Made with [Cursor](https://cursor.com)