### PR TITLE
Fix shell command injection in desktop openUrl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
 
     # Run tests.
     - run: nim c tests/test.nim
+    - run: nim r tests/test_openurl.nim
     - run: nim r -d:useCpu tests/test_cpu_pixels.nim
       if: matrix.os == 'windows-latest'
 

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -1395,7 +1395,10 @@ proc setConfig*(appName: string, fileName: string, content: string) =
 
 proc openUrl*(url: string) =
   ## Open a URL in the default browser.
-  discard execShellCmd("xdg-open " & url)
+  let process = startProcess("xdg-open", args = [url],
+    options = {poUsePath, poParentStreams})
+  defer: process.close()
+  discard process.waitForExit()
 
 proc openTempTextFile*(title, text: string) =
   ## Open a text file in the default text editor.

--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1,5 +1,5 @@
 import
-  std/[os, strutils, times, unicode, pathnorm],
+  std/[os, osproc, strutils, times, unicode, pathnorm],
   pixie/fileformats/png, pixie/images, utils, vmath,
   ../../[common, internal], macdefs
 
@@ -1572,7 +1572,10 @@ proc openTempTextFile*(title, text: string) =
 
 proc openUrl*(url: string) =
   ## Open a URL in the default web browser.
-  discard execShellCmd("open " & url)
+  let process = startProcess("open", args = ["--", url],
+    options = {poUsePath, poParentStreams})
+  defer: process.close()
+  discard process.waitForExit()
 
 proc fileDialogExtensions(filters: seq[FileDialogFilter]): seq[string] =
   ## Collects unique file extensions without wildcards or dots.

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -2823,7 +2823,17 @@ proc setConfig*(appName: string, fileName: string, content: string) =
 
 proc openUrl*(url: string) =
   ## Open a URL in the default web browser.
-  discard execShellCmd("start " & url)
+  let
+    operation = wstr("open")
+    target = wstr(url)
+  discard ShellExecuteW(
+    0,
+    cast[LPCWSTR](operation[0].addr),
+    cast[LPCWSTR](target[0].addr),
+    nil,
+    nil,
+    SW_SHOWNORMAL
+  )
 
 proc openTempTextFile*(title, text: string) =
   ## Open a text file in the default text editor.

--- a/src/windy/platforms/win32/platform.nim
+++ b/src/windy/platforms/win32/platform.nim
@@ -4,6 +4,8 @@ import
   pixie/fileformats/bmp, pixie/images,
   urlly, utils, vmath, windefs, zippy
 
+from std/winlean import shellExecuteW
+
 when defined(useDirectX):
   {.hint: "Using DirectX backend".}
 elif defined(useVulkan):
@@ -2823,17 +2825,9 @@ proc setConfig*(appName: string, fileName: string, content: string) =
 
 proc openUrl*(url: string) =
   ## Open a URL in the default web browser.
-  let
-    operation = wstr("open")
-    target = wstr(url)
-  discard ShellExecuteW(
-    0,
-    cast[LPCWSTR](operation[0].addr),
-    cast[LPCWSTR](target[0].addr),
-    nil,
-    nil,
-    SW_SHOWNORMAL
-  )
+  # Windows resolves URL associations through ShellExecute, not CreateProcess.
+  discard shellExecuteW(0, newWideCString("open"), newWideCString(url),
+    nil, nil, SW_SHOWNORMAL)
 
 proc openTempTextFile*(title, text: string) =
   ## Open a text file in the default text editor.

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -1051,15 +1051,6 @@ proc Shell_NotifyIconW*(
   lpData: PNOTIFYICONDATAW
 ): BOOL {.dynlib: "shell32".}
 
-proc ShellExecuteW*(
-  hwnd: HWND,
-  lpOperation: LPCWSTR,
-  lpFile: LPCWSTR,
-  lpParameters: LPCWSTR,
-  lpDirectory: LPCWSTR,
-  nShowCmd: int32
-): HINSTANCE {.dynlib: "shell32".}
-
 proc WinHttpOpen*(
   lpszAgent: LPCWSTR,
   dwAccessType: DWORD,

--- a/src/windy/platforms/win32/windefs.nim
+++ b/src/windy/platforms/win32/windefs.nim
@@ -1051,6 +1051,15 @@ proc Shell_NotifyIconW*(
   lpData: PNOTIFYICONDATAW
 ): BOOL {.dynlib: "shell32".}
 
+proc ShellExecuteW*(
+  hwnd: HWND,
+  lpOperation: LPCWSTR,
+  lpFile: LPCWSTR,
+  lpParameters: LPCWSTR,
+  lpDirectory: LPCWSTR,
+  nShowCmd: int32
+): HINSTANCE {.dynlib: "shell32".}
+
 proc WinHttpOpen*(
   lpszAgent: LPCWSTR,
   dwAccessType: DWORD,

--- a/tests/test_openurl.nim
+++ b/tests/test_openurl.nim
@@ -29,6 +29,7 @@ else:
 proc main() =
   let urls = [
     "https://example.com/",
+    "mailto:test@example.com?subject=Hello&body=World",
     "https://example.com/?first=1&second=2#fragment",
     "https://example.com/a b/\"quoted\"/'single'",
     "https://example.com/$(echo injected > windy-openurl-injected)",

--- a/tests/test_openurl.nim
+++ b/tests/test_openurl.nim
@@ -1,0 +1,76 @@
+import windy
+
+when defined(windows):
+  import windy/platforms/win32/[utils, windefs]
+
+  var openedUrls: seq[string]
+
+  proc recordOpenUrl(
+    hwnd: HWND,
+    operation, target, parameters, directory: LPCWSTR,
+    showCmd: int32
+  ): HINSTANCE {.stdcall, exportc: "ShellExecuteW".} =
+    # Capture the native API boundary without launching a browser.
+    doAssert hwnd == 0
+    doAssert $operation == "open"
+    doAssert parameters == nil
+    doAssert directory == nil
+    doAssert showCmd == SW_SHOWNORMAL
+    openedUrls.add($target)
+    return 33
+else:
+  import std/[json, os, tempfiles]
+
+  # A copy of this executable stands in for open/xdg-open on PATH.
+  if getEnv("WINDY_OPENURL_RECORD") != "":
+    writeFile(getEnv("WINDY_OPENURL_RECORD"), $(%commandLineParams()))
+    quit(0)
+
+proc main() =
+  let urls = [
+    "https://example.com/",
+    "https://example.com/?first=1&second=2#fragment",
+    "https://example.com/a b/\"quoted\"/'single'",
+    "https://example.com/$(echo injected > windy-openurl-injected)",
+    "https://example.com/`echo injected > windy-openurl-injected`",
+    "https://example.com/; echo injected > windy-openurl-injected",
+    "https://example.com/| echo injected > windy-openurl-injected",
+    "https://example.com/\necho injected > windy-openurl-injected",
+    "https://example.com/%PATH%/$HOME/!name!/a\\b",
+    "https://example.com/café/日本語/🌍?x=1&y=2"
+  ]
+
+  when defined(windows):
+    for url in urls:
+      openUrl(url)
+    doAssert openedUrls == @urls
+  else:
+    let
+      tempDir = createTempDir("windy-openurl-", "")
+      originalDir = getCurrentDir()
+      originalPath = getEnv("PATH")
+      recordPath = tempDir / "args.json"
+      opener = tempDir / (when defined(macosx): "open" else: "xdg-open")
+    defer:
+      setCurrentDir(originalDir)
+      putEnv("PATH", originalPath)
+      delEnv("WINDY_OPENURL_RECORD")
+      removeDir(tempDir)
+
+    copyFile(getAppFilename(), opener)
+    setFilePermissions(opener, {fpUserRead, fpUserWrite, fpUserExec})
+    setCurrentDir(tempDir)
+    putEnv("PATH", tempDir & ":" & originalPath)
+    putEnv("WINDY_OPENURL_RECORD", recordPath)
+
+    for url in urls:
+      if fileExists(recordPath):
+        removeFile(recordPath)
+      openUrl(url)
+      let expected = when defined(macosx): @["--", url] else: @[url]
+      doAssert parseFile(recordPath) == %expected
+      doAssert not fileExists("windy-openurl-injected")
+
+  echo "Windy openUrl regression test passed"
+
+main()

--- a/tests/test_openurl.nims
+++ b/tests/test_openurl.nims
@@ -1,0 +1,3 @@
+when defined(windows):
+  # Link the test's ShellExecuteW recorder instead of loading shell32.dll.
+  switch("dynlibOverride", "shell32")

--- a/tests/test_openurl.nims
+++ b/tests/test_openurl.nims
@@ -1,3 +1,3 @@
 when defined(windows):
   # Link the test's ShellExecuteW recorder instead of loading shell32.dll.
-  switch("dynlibOverride", "shell32")
+  switch("dynlibOverride", "shell32.dll")


### PR DESCRIPTION
`openUrl()` previously concatenated its input into `start`, `open`, or `xdg-open` shell commands. A normal URL such as `https://example.com/?first=1&second=2` could be split at `&`, and shell metacharacters in an untrusted URL could execute additional commands.

Pass the URL directly to `ShellExecuteW` using Nim's existing `std/winlean` binding and `newWideCString` on Windows. On macOS and Linux, launch `open` / `xdg-open` with explicit argument arrays and no shell evaluation; macOS also gets an end-of-options marker. The POSIX launchers still wait for the opener to exit and close its process handle.

Windows uses the association API because `startProcess` launches executables and cannot resolve a URL to its default browser. Unlike the POSIX openers, `start` is a `cmd.exe` built-in. Nim's own `std/browsers` helper also uses `ShellExecuteW` on Windows; this PR uses the existing binding directly to preserve links such as `mailto:` on older supported Nim versions.

Add a regression test to the three-platform CI matrix. It captures the Windows API call or runs a recording executable in place of the POSIX opener, so it checks the exact URL without opening a browser. Cases cover query-string ampersands, spaces, quotes, command substitution, separators, redirection, newlines, environment-variable syntax, backslashes, and Unicode.

Validation on Windows with Nim 2.2.10:

- `nim r tests/test_openurl.nim` passed.
- `nim c tests/test.nim` and `nim c examples/openurl.nim` passed.
- Linux/amd64 and macOS/arm64 `nim check` passed for the regression test and the openurl example.
- Native Linux and macOS execution is covered by the PR's CI jobs.
