### PR TITLE
Acknowledge _NET_WM_SYNC_REQUEST only after the resized frame on X11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
       if: matrix.os == 'macos-latest'
     - run: nim r -d:useCpu tests/test_cpu_pixels.nim
       if: matrix.os == 'windows-latest'
+    - run: |
+        sudo apt-get install -y xvfb libgl1-mesa-dri
+        LIBGL_ALWAYS_SOFTWARE=1 xvfb-run -a nim r tests/test_x11.nim
+      if: matrix.os == 'ubuntu-latest'
 
     # Build native examples.
     - run: nim c examples/basic.nim

--- a/src/windy/platforms/linux/x11.nim
+++ b/src/windy/platforms/linux/x11.nim
@@ -42,6 +42,8 @@ type
     im: XIM
     xSyncCounter: XSyncCounter
     lastSync: XSyncValue
+    syncState: SyncState
+    syncDeadline: float64
 
     closeRequested, closed: bool
     innerDecorated: bool
@@ -60,6 +62,16 @@ type
     motiv
     kwm
     other
+
+  SyncState = enum
+    ## Where a window is in the _NET_WM_SYNC_REQUEST handshake.
+    SyncIdle ## No request outstanding.
+    SyncRequested ## Request received, waiting for its ConfigureNotify.
+    SyncConfigured ## ConfigureNotify handled, acknowledge after the next frame.
+
+const
+  syncConfigureTimeout = 0.010
+    ## Seconds to wait for the ConfigureNotify that follows a sync request.
 
 var
   quitRequested*: bool
@@ -856,8 +868,13 @@ proc pollEvents(window: Window) =
   window.buttonPressed = {}
   window.buttonReleased = {}
 
-  # signal that frame was drawn
-  display.XSyncSetCounter(window.xSyncCounter, window.lastSync)
+  # Signal that the frame for the last _NET_WM_SYNC_REQUEST was drawn. This
+  # only happens once the matching ConfigureNotify was handled and a frame has
+  # gone by, otherwise a compositor such as KWin shows a frame that is still
+  # the old size.
+  if window.syncState == SyncConfigured:
+    display.XSyncSetCounter(window.xSyncCounter, window.lastSync)
+    window.syncState = SyncIdle
 
   var ev: XEvent
 
@@ -888,7 +905,16 @@ proc pollEvents(window: Window) =
   proc handleRune(window: Window, rune: Rune) =
     handleRuneTemplate()
 
-  while display.XCheckIfEvent(ev.addr, checkEvent, cast[pointer](window)):
+  while true:
+    if not display.XCheckIfEvent(ev.addr, checkEvent, cast[pointer](window)):
+      if window.syncState == SyncRequested and
+        epochTime() < window.syncDeadline:
+        # The window manager sends the ConfigureNotify right after the sync
+        # request. Wait for it so the next frame is already the new size.
+        sleep(1)
+        continue
+      break
+
     case ev.kind
 
     of xeClientMessage:
@@ -903,6 +929,8 @@ proc pollEvents(window: Window) =
           lo: cast[uint32](ev.client.data.l[2]),
           hi: cast[int32](ev.client.data.l[3])
         )
+        window.syncState = SyncRequested
+        window.syncDeadline = epochTime() + syncConfigureTimeout
 
       elif ev.client.messageType == xaXdndEnter:
         # XDnD drag entered.
@@ -1034,6 +1062,9 @@ proc pollEvents(window: Window) =
           window.onResize()
         if window.onFrame != nil:
           window.onFrame()
+
+      if window.syncState == SyncRequested:
+        window.syncState = SyncConfigured
 
     of xeMotion:
       window.mousePrevPos = window.mousePos

--- a/src/windy/platforms/linux/x11/xlib.nim
+++ b/src/windy/platforms/linux/x11/xlib.nim
@@ -354,5 +354,6 @@ proc XSyncCreateCounter*(d: Display, v: XSyncValue): XSyncCounter
 proc XSyncDestroyCounter*(d: Display, c: XSyncCounter)
 
 proc XSyncSetCounter*(d: Display, c: XSyncCounter; v: XSyncValue)
+proc XSyncQueryCounter*(d: Display, c: XSyncCounter; v: ptr XSyncValue): cint
 
 {.pop.}

--- a/tests/test_x11.nim
+++ b/tests/test_x11.nim
@@ -1,0 +1,92 @@
+when defined(linux):
+  include ../src/windy/platforms/linux/x11
+
+  ## Plays the window manager side of the _NET_WM_SYNC_REQUEST handshake so
+  ## it runs under a bare Xvfb. The rule under test: the sync counter is only
+  ## updated after the ConfigureNotify for the request was handled and a
+  ## frame has gone by, never before, and never without a request.
+
+  proc counterValue(window: Window): XSyncValue =
+    doAssert display.XSyncQueryCounter(window.xSyncCounter, result.addr) != 0
+
+  proc sendSyncRequest(window: Window, lo: uint32, hi: int32) =
+    ## Sends what a window manager sends right before resizing the window.
+    let xaWMProtocols = display.XInternAtom("WM_PROTOCOLS", 0)
+    let message = newClientMessage(
+      window.handle,
+      xaWMProtocols,
+      [xaNetWMSyncRequest.clong, 0.clong, lo.clong, hi.clong]
+    )
+    window.handle.send(message)
+    display.XSync()
+
+  proc resize(window: Window, size: IVec2) =
+    display.XResizeWindow(window.handle, size.x.uint32, size.y.uint32)
+    display.XSync()
+
+  proc testSyncRequestAck() =
+    let window = newWindow("Sync", ivec2(200, 100), visible = false)
+    doAssert window.xSyncCounter.int != 0, "Xvfb lacks the SYNC extension"
+
+    var resizes: seq[IVec2]
+    window.onResize = proc() =
+      resizes.add window.size
+
+    doAssert window.counterValue.lo == 0
+    doAssert window.syncState == SyncIdle
+
+    # A resize without a request never touches the counter.
+    window.resize(ivec2(210, 110))
+    pollEvents()
+    doAssert resizes == @[ivec2(210, 110)]
+    doAssert window.counterValue.lo == 0
+    doAssert window.syncState == SyncIdle
+
+    # Request and ConfigureNotify in one poll: the ack waits for a frame.
+    window.sendSyncRequest(1, 0)
+    window.resize(ivec2(300, 200))
+    pollEvents()
+    doAssert resizes[^1] == ivec2(300, 200)
+    doAssert window.syncState == SyncConfigured
+    doAssert window.counterValue.lo == 0, "acked before the resized frame"
+    pollEvents()
+    doAssert window.syncState == SyncIdle
+    doAssert window.counterValue.lo == 1
+
+    # Request in one poll, ConfigureNotify in a later one. The poll that saw
+    # the request must not ack, and must not wait longer than the timeout.
+    window.sendSyncRequest(2, 0)
+    let start = epochTime()
+    pollEvents()
+    doAssert epochTime() - start < 1.0, "poll did not give up waiting"
+    doAssert window.syncState == SyncRequested
+    doAssert window.counterValue.lo == 1, "acked without a ConfigureNotify"
+    pollEvents()
+    doAssert window.counterValue.lo == 1
+    window.resize(ivec2(400, 300))
+    pollEvents()
+    doAssert resizes[^1] == ivec2(400, 300)
+    doAssert window.syncState == SyncConfigured
+    doAssert window.counterValue.lo == 1
+    pollEvents()
+    doAssert window.syncState == SyncIdle
+    doAssert window.counterValue.lo == 2
+
+    # The full 64-bit value round-trips and a newer request wins.
+    window.sendSyncRequest(3, 0)
+    window.sendSyncRequest(5, 1)
+    window.resize(ivec2(500, 400))
+    pollEvents()
+    pollEvents()
+    let value = window.counterValue
+    doAssert value.lo == 5 and value.hi == 1
+
+    # Once idle, polling leaves the counter alone.
+    pollEvents()
+    doAssert window.counterValue.lo == 5
+    doAssert window.syncState == SyncIdle
+
+    window.close()
+
+  testSyncRequestAck()
+  echo "test_x11 passed"


### PR DESCRIPTION
## Summary

On X11 the `_NET_WM_SYNC_REQUEST` counter was set at the top of every `pollEvents`, before that poll's events were handled. If the window manager's sync request arrived at the end of one poll and its `ConfigureNotify` in the next, windy acknowledged the frame while the window was still drawn at the old size. KWin then composited that frame, which is the one-frame black stripe on the right and bottom edge reported in #156.

This tracks the handshake per window:

- sync request → `SyncRequested`, remember the counter value
- `ConfigureNotify` → `SyncConfigured`
- next poll (after a frame at the new size went by) → `XSyncSetCounter`, back to `SyncIdle`

The event loop also waits up to 10 ms for the `ConfigureNotify` that follows a sync request, so the frame drawn after the poll is already the new size. A request that never gets a configure is never acknowledged, which is what the EWMH protocol expects.

This follows the intent of #156 by @levovix0. Left out on purpose: the temporary vsync disable after a resize and the cached `size` getter, which are unrelated to the sync handshake (the cache also made `size=` wait its full timeout, since `blockUntil` never polls events).

## Test

`tests/test_x11.nim` plays the window manager side under a bare Xvfb: it sends the `_NET_WM_SYNC_REQUEST` client message, resizes with `XResizeWindow`, and reads the counter back with `XSyncQueryCounter`. It checks:

- a resize without a request never touches the counter
- request and configure in one poll: no ack until the next poll
- request in one poll, configure in a later poll: no ack until the configure was handled and a frame went by, and the waiting poll gives up quickly
- the full 64-bit value round-trips and a newer request wins
- an idle window's counter is left alone

Against the old unconditional ack the test fails at the split case, which is exactly the reported bug. CI runs it on Ubuntu under `xvfb-run` with Mesa llvmpipe.

## Validation

- `nim r tests/test_x11.nim` under Xvfb (Docker, linux/amd64, Nim 2.2.4): passes
- same test against the old ack: fails at the split-poll case
- `nim c tests/test.nim`, `examples/basic.nim`, `examples/callbacks.nim`, `examples/property_changes.nim` on Linux: compile

Not verified on a real KWin session, I do not have one at hand. @levovix0 if you can try this on your setup that would confirm the visual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
