### PR TITLE
Let browser games receive typed text and Command-key shortcuts

### DIFF
--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -656,9 +656,15 @@ proc onWheel(eventType: cint, wheelEvent: ptr EmscriptenWheelEvent, userData: po
     window.onScroll()
   return 1
 
+proc keyEventToButton(event: ptr EmscriptenKeyboardEvent): Button =
+  case $cast[cstring](event.code[0].addr)
+  of "MetaLeft": KeyLeftSuper
+  of "MetaRight": KeyRightSuper
+  else: keyCodeToButton(event.keyCode)
+
 proc onKeyDown(eventType: cint, keyEvent: ptr EmscriptenKeyboardEvent, userData: pointer): EM_BOOL {.cdecl.} =
   let window = cast[Window](userData)
-  let button = keyCodeToButton(keyEvent.keyCode)
+  let button = keyEventToButton(keyEvent)
   window.handleButtonPress(button)
   # Canceling a printable keydown suppresses the keypress that delivers runes.
   # Keep navigation and shortcuts captured; onKeyPress consumes text input.
@@ -670,7 +676,7 @@ proc onKeyDown(eventType: cint, keyEvent: ptr EmscriptenKeyboardEvent, userData:
 
 proc onKeyUp(eventType: cint, keyEvent: ptr EmscriptenKeyboardEvent, userData: pointer): EM_BOOL {.cdecl.} =
   let window = cast[Window](userData)
-  let button = keyCodeToButton(keyEvent.keyCode)
+  let button = keyEventToButton(keyEvent)
   window.handleButtonRelease(button)
   return 1
 

--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -646,7 +646,7 @@ proc onWheel(eventType: cint, wheelEvent: ptr EmscriptenWheelEvent, userData: po
   # very different magnitudes. Use a flat OS-based multiplier instead.
   let scale =
     if "Mac" in platform: -1.0f
-    else: 0.2f
+    else: -0.2f
   let
     x = wheelEvent.deltaX.float32 * scale
     y = wheelEvent.deltaY.float32 * scale

--- a/src/windy/platforms/emscripten/platform.nim
+++ b/src/windy/platforms/emscripten/platform.nim
@@ -660,6 +660,12 @@ proc onKeyDown(eventType: cint, keyEvent: ptr EmscriptenKeyboardEvent, userData:
   let window = cast[Window](userData)
   let button = keyCodeToButton(keyEvent.keyCode)
   window.handleButtonPress(button)
+  # Canceling a printable keydown suppresses the keypress that delivers runes.
+  # Keep navigation and shortcuts captured; onKeyPress consumes text input.
+  if window.runeInputEnabled and not keyEvent.ctrlKey and not keyEvent.metaKey:
+    let key = $cast[cstring](keyEvent.key[0].addr)
+    if key.runeLen == 1:
+      return 0
   return 1
 
 proc onKeyUp(eventType: cint, keyEvent: ptr EmscriptenKeyboardEvent, userData: pointer): EM_BOOL {.cdecl.} =


### PR DESCRIPTION
In the browser game’s name field, Backspace worked but typed letters did not appear. Windy cancelled printable keydown events before the browser could deliver the keypress used for text input. Allow that event only while text input is enabled, while keeping the existing handling of navigation and shortcuts.

Also recognize the left and right Command keys, which were missing from the browser button mapping. This lets a held Command-A reach a Mac-style text control. Correct the wheel sign in the non-Mac browser path; the Mac browser path already scrolled correctly.

Validation in the actual Polyworld menu, using real Chrome keyboard and mouse input:

- Upstream Windy leaves a typed name blank; the text-input fix displays it.
- Before the Command-key mapping, Command-A did not select the name. With the mapping and the modifier held across frames, “Hello” is visibly selected and replaced by “R.”
- Typing outside the name field leaves it unchanged. Scrolling down and back up moves the quest list in both directions. The non-Mac browser path was also exercised by overriding the browser platform string; this is not native Windows/Linux input evidence.

A shortcut whose press and release both arrive between drawn frames can still be missed by the text control. This PR does not fix that separate timing problem. IME composition, clipboard entry, and native OS wheel settings remain unverified by these checks.

[Polyworld #9](https://github.com/Metta-AI/polyworld/pull/9) consumes this fix. The browser artifacts were built with Windy commit `812ed158f735b75320c0b7d5db2b7e56f448d406`. Native build CI is useful but does not establish the browser interactions above.

[Current CI run](https://github.com/treeform/windy/actions/runs/34400664545) passed on Linux, macOS, and Windows. The runtime limits above still apply.
