### PR TITLE
Export a no-op loadExtensions on macOS for the Metal and CPU backends

### DIFF
--- a/src/windy/platforms/macos/platform.nim
+++ b/src/windy/platforms/macos/platform.nim
@@ -1243,6 +1243,12 @@ proc swapBuffers*(window: Window) =
   else:
     window.inner.contentView.NSOpenGLView.openGLContext.flushBuffer()
 
+when defined(useMetal4) or defined(useCpu):
+  proc loadExtensions*() =
+    ## Nothing to load without OpenGL. Exported so callers can call
+    ## loadExtensions() on every backend, as Win32 and Emscripten already allow.
+    discard
+
 proc presentPixels*(window: Window, image: Image) =
   ## Presents a CPU-rendered Pixie image into the macOS window content view.
   when defined(useCpu):


### PR DESCRIPTION
## Why

`loadExtensions()` is the OpenGL extension loader. Examples and downstream code call it once after `makeContextCurrent`, unconditionally, so the same source builds against every backend. That only works if *some* `loadExtensions` exists on non-OpenGL backends too.

Windy already provides that on Win32 (a no-op under `useDirectX`, `useVulkan` and `useCpu`) and on Emscripten. macOS did not: under `useMetal4` or `useCpu` the `opengl` import is skipped and nothing exports the symbol. Silky worked around that by defining its own no-op, which then collided with Windy's on Win32 CPU builds:

```
basicwindow.nim(20, 15) Error: ambiguous call; both platform.loadExtensions() [proc declared in windy/platforms/win32/platform.nim(1121, 8)] and silky.loadExtensions() [proc declared in silky/src/silky.nim(28, 10)] match for: ()
```

## What

Add the same no-op to the macOS platform under `useMetal4` or `useCpu`, next to the existing no-op branches of `makeContextCurrent` and `swapBuffers`. Windy is the one place that knows which backend is active, so it is the right owner of this symbol. After this, `loadExtensions()` is callable on every platform and backend Windy supports, and Silky can drop its stand-in (treeform/silky PR to follow).

Linux is unchanged: it has no non-OpenGL backend branches.

## Testing

I cannot build the macOS target from this machine. The change is a six-line no-op proc mirroring the Win32 one, placed after `swapBuffers` in the same `when` shape those procs already use. The Win32 and Emscripten platforms are untouched. Silky's full example set compiles against Windy on Windows with OpenGL, DirectX, Vulkan and CPU backends on Nim 2.2.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
